### PR TITLE
Add initial .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,24 @@
+# Fortran module files
+*.mod
+*.smod
+
+# Executables
+*.exe
+*.out
+*.app
+
+# Processed files
+*.continueless.*
+*.tokens.*
+
+# LaTeX temporary files
+**.tex
+**/*.aux
+**/*.bbl
+**/*.fdb_latexmk
+**/*.fls
+**/*.log
+
+# Miscellany
+.DS_Store
+requirements/requirements.txt


### PR DESCRIPTION
Initial .gitignore. Taken from Fortran template plus ignoring LaTeX temp files and other miscellaneous files (such as Mac `.DS_Store` files).