### PR TITLE
Add #warning

### DIFF
--- a/drafts/25-revise-24-177 Fortran preprocessor requirements.txt
+++ b/drafts/25-revise-24-177 Fortran preprocessor requirements.txt
@@ -102,6 +102,7 @@ Macros are expanded in comment lines that appear to be pragma directives
     #if, #elif, #else
     #include
     #error
+    #warning
     #pragma
 
 Just as #include lines interpolate the source from other files, the

--- a/drafts/25-revise-24-177 Fortran preprocessor requirements.txt
+++ b/drafts/25-revise-24-177 Fortran preprocessor requirements.txt
@@ -99,7 +99,7 @@ Macros are expanded in comment lines that appear to be pragma directives
              that uses the ellipsis notation in the parameters
     #undef
     #ifdef and #ifndef
-    #if, #elif, #else
+    #if, #elif, #else, #endif
     #include
     #error
     #warning


### PR DESCRIPTION
Add #warning to the list of supported directives

`#warning` was standardized in C23/C++23 after being widely implemented
for years, and there seems to be consensus that Fortran's preprocessor
should also have it.

This notably enables a standardized mechanism for issuing
coarse-granularity deprecation messages during compilation.

Resolves #7