### PR TITLE
Remove __STDF_VERSION__ and clarify __STDF__

### DIFF
--- a/drafts/25-revise-24-177 Fortran preprocessor requirements.txt
+++ b/drafts/25-revise-24-177 Fortran preprocessor requirements.txt
@@ -132,7 +132,6 @@ preprocessor will include the text from Fortran INCLUDE lines
     __DATE__
     __TIME__
     __STDF__
-    __STDF_VERSION__
     __VA_ARGS__  in the replacement-list of a function-like macro
       that uses the ellipsis notation in the parameters.
     __VA_OPT__  in the replacement-list of a function-like macro

--- a/drafts/25-revise-24-177 Fortran preprocessor requirements.txt
+++ b/drafts/25-revise-24-177 Fortran preprocessor requirements.txt
@@ -137,10 +137,11 @@ preprocessor will include the text from Fortran INCLUDE lines
     __VA_OPT__  in the replacement-list of a function-like macro
       that uses the ellipsis notation in the parameters.
 
-__STDF__ and __STDF_VERSION__ are analogs to the CPP __STDC__ (1) and
-__STDC_VERSION__ (e.g., 201710) macros, allowing conditional compilation
-based on the version of the Fortran standard supported by the processor.
-
+__STDF__ is an analog to __STDC__ in C and __cplusplus in C++.  Its primary
+role is to provide preprocessor-visible and vendor-independent identification
+of the underlying target language (i.e., "the processor is Fortran"), which
+enables one to write multi-language header files with conditional compilation
+based on language.  
 
 4.5. Fortran awareness during macro expansion
 ---------------------------------------------


### PR DESCRIPTION
There has been significant (and well-founded) pushback on the `__STDF_VERSION__` predefined macro proposed in 24-177, on the basis that it's too coarse-grained to ever be reliably useful as a language feature test in practice. We should remove it.

There has also been confusion over the purpose of the proposed `__STDF__`, so we should clarify that. 

Resolves #9 