### PR TITLE
Add missing Fortran operators to preprocessor #if, #elif expressions

### DIFF
--- a/drafts/25-revise-24-177 Fortran preprocessor requirements.txt
+++ b/drafts/25-revise-24-177 Fortran preprocessor requirements.txt
@@ -122,7 +122,8 @@ preprocessor will include the text from Fortran INCLUDE lines
 ---------------------------------------------------
     - The "defined" operator
     - From C: && || == != < > <= >= + / * ! & | ^ ~ ( )
-    - From Fortran: = /= .AND. .OR. .NOT.
+    - From Fortran: = /= .AND. .OR. .NOT. .EQ. .NE.
+                    .LT. .LE. .GT. .GE. .EQV. .NEQV.
 
 
 4.4 Macros defined by the preprocessor


### PR DESCRIPTION
This allows the same #define-d value to de used in Fortran source and in directive expressions.

Fixes #13.