### PR TITLE
Avoid introducing new predefined macros

### DIFF
--- a/drafts/25-revise-24-177 Fortran preprocessor requirements.txt
+++ b/drafts/25-revise-24-177 Fortran preprocessor requirements.txt
@@ -132,17 +132,6 @@ preprocessor will include the text from Fortran INCLUDE lines
     __FILE__
     __DATE__
     __TIME__
-    __STDF__
-    __VA_ARGS__  in the replacement-list of a function-like macro
-      that uses the ellipsis notation in the parameters.
-    __VA_OPT__  in the replacement-list of a function-like macro
-      that uses the ellipsis notation in the parameters.
-
-__STDF__ is an analog to __STDC__ in C and __cplusplus in C++.  Its primary
-role is to provide preprocessor-visible and vendor-independent identification
-of the underlying target language (i.e., "the processor is Fortran"), which
-enables one to write multi-language header files with conditional compilation
-based on language.
 
 4.5. Fortran awareness during macro expansion
 ---------------------------------------------


### PR DESCRIPTION
We may wish to add these later, but I think we should avoid bringing these up now. I'm fairly certain that these will just become a distraction at the meeting.

I'm also of the opinion that we shouldn't add `__STDF__` at all. No FPP that I've tested supports it already, so including it isn't an attempt to standardize existing behavior; it's entirely a new feature. And it's a new feature that probably isn't very useful, as we discussed in last week's meeting.

`__VA_ARGS__` I think is neat and possibly worth including, but out of nagfor, ifx, gfortran, and flang, only flang supports it currently. So it's not like it's already a common feature.

If we're introducing completely (or nearly completely) new behavior, I think it makes more sense to give them dedicates papers to move at the committee meeting where we can debate only that one new feature. Otherwise, we'll end up debating it anyway, but when we should be discussing everything else in this paper!

(This argument also applies to other "new" features like proposing a new `#pragma`, though for whatever reason, proposing `#pragma` seems more acceptable to me. Probably my biases 😄 But I wouldn't mind seeing `#pragma` removed from this paper too and reintroduced in a separate feature paper where we can discuss it specifically.)