### PR TITLE
Add all the operators that CPP allows in #if / #elif expressions

### DIFF
--- a/drafts/25-114.txt
+++ b/drafts/25-114.txt
@@ -197,7 +197,13 @@ via #include.
 4.3 Operators accepted in #if and #elif expressions
 ---------------------------------------------------
     - The "defined" operator
-    - From C: && || == != < > <= >= + / * ! & | ^ ~ ( )
+    - From C: && || !          (logical operators)
+              == != < > <= >=  (equality- and relational-expression)
+              + -              (additive-expression, also unary forms)
+              * / %            (multiplicative-expression)
+              & | ^ ~ << >>    (bitwise operators)
+              ? :              (conditional-expression)
+              ( )              (parenthetical grouping)
     - From Fortran: = /= .AND. .OR. .NOT.
 
 


### PR DESCRIPTION
This adds the five-ish operators accepted by CPP in `#if` and `#elif` that were missing from 25-114r0.

Also rearrange/regroup the operator list and add explanatory parentheticals, for readers less familiar with C grammar. I assume a future syntax paper will explode this out further to show the full grammar, but that seems redundant for requirements and I think this conveys the right intuition without being too pedantic.

Resolves issue #33

