### PR TITLE
No expansion: remove mention of FORMAT and IMPLICIT

### DIFF
--- a/drafts/25-114.txt
+++ b/drafts/25-114.txt
@@ -239,8 +239,8 @@ FPP will not expand in fixed-form
 
 FPP will not expand tokens in either fixed- or free-form:
     - In character constants
-    - In FORMAT statements
-    - In the letter-spec-list in an IMPLICIT statement.
+    - In Hollerith constants in DATA statements and argument lists,
+    - In Hollerith format descriptors.
 
 
 4.6 Output of Phase 2

--- a/drafts/25-114.txt
+++ b/drafts/25-114.txt
@@ -238,7 +238,8 @@ FPP will not expand in fixed-form
 
 
 FPP will not expand tokens in either fixed- or free-form:
-    - In character constants
+    - In character literal constants.
+    - In character string edit descriptors (quoted character strings).
 
 
 4.6 Output of Phase 2

--- a/drafts/25-114.txt
+++ b/drafts/25-114.txt
@@ -239,8 +239,6 @@ FPP will not expand in fixed-form
 
 FPP will not expand tokens in either fixed- or free-form:
     - In character constants
-    - In Hollerith constants in DATA statements and argument lists,
-    - In Hollerith format descriptors.
 
 
 4.6 Output of Phase 2


### PR DESCRIPTION
After discussion, remove prohibition on expansion in `FORMAT` specifications, and `IMPLICIT` statements. Also, treat Hollerith data and format specifiers as we treat character constants.