### PR TITLE
Remove references to Fortran operators and constants

### DIFF
--- a/drafts/25-114.txt
+++ b/drafts/25-114.txt
@@ -207,7 +207,10 @@ expansion, and may for example include any tokens valid in Fortran or C.
               & | ^ ~ << >>    (bitwise operators)
               ? :              (conditional-expression)
               ( )              (parenthetical grouping)
-
+Earlier revisions of this document considered allowing Fortran syntax in
+#if and #elif expressions, such as:
+ = /= .AND. .OR. .NOT. .TRUE. .FALSE.
+but we eventually decided to omit these due to a lack of compelling use cases.
 
 4.4 Macros defined by the preprocessor
 ---------------------------------------------

--- a/drafts/25-114.txt
+++ b/drafts/25-114.txt
@@ -142,25 +142,19 @@ Comment handling:
        (processor-specific, such as '!$omp', or '!$acc', or others).
 
 Constant expressions in #if and #elif:
-    1. Expressions in #if and #elif directives allow operators from
-       both Fortran and CPP.
+    1. Expressions in #if and #elif directives allow operators from CPP.
     2. Expressions in #if and #elif directives must be integer constant
        expressions as specified for CPP (with the extensions described
        below), and evaluate to INTEGER values. As in CPP, zero values
        are treated as 'false'. Non-zero values are treated as 'true'.
-    3. .FALSE. and .false. are treated as the integer 0.
-       .TRUE. and .true. are treated as the integer 1.
-    4. Any undefined identifiers that remain after macro expansion
+    3. Any undefined identifiers that remain after macro expansion
        (including those lexically identical to keywords or intrinsics)
        are treated as zero, as in CPP.
-    5. C character constants (such as 'A', '\n') are treated as
+    4. C character constants (such as 'A', '\n') are treated as
        integer values, as they are in CPP.
-    6. The Fortran operators .AND., .OR., .NOT., =, and /= evaluate
-       to the same values as the C operators &&, ||, !, ==, and !=,
-       respectively.
-    7. There are no KIND specifiers on integer constants in the
+    5. There are no KIND specifiers on integer constants in the
        preprocessor.
-    8. Integer expressions in preprocessor directives are evaluated
+    6. Integer expressions in preprocessor directives are evaluated
        using the integer kind that has the largest decimal exponent range
        supported by the processor.
 
@@ -213,7 +207,6 @@ expansion, and may for example include any tokens valid in Fortran or C.
               & | ^ ~ << >>    (bitwise operators)
               ? :              (conditional-expression)
               ( )              (parenthetical grouping)
-    - From Fortran: = /= .AND. .OR. .NOT.
 
 
 4.4 Macros defined by the preprocessor


### PR DESCRIPTION
After discussion today, JoR subgroup agreed that we had no strong use cases for adding Fortran relational and logical operators to the Fortran preprocessor. Such operators do not appear with any frequency in our corpus of example Fortran projects.

We agreed to limit the operators used to construct #if and #elif expressions to those available in the C preprocessor for constructing constant expressions.

Fixes #38.