### PR TITLE
Rename section 4.2 and move __VA_*

### DIFF
--- a/drafts/25-114.txt
+++ b/drafts/25-114.txt
@@ -186,13 +186,21 @@ interpolated by INCLUDE lines will be treated as if it had been included
 via #include.
 
 
-4.2 Tokens accepted on #define directives
------------------------------------------
-    - # (stringify)
-    - ## (token concatenation)
-    - Any valid Fortran token
-    - Any C operator allowed in a #if or #elif expression
-    - Any macro names defined by the preprocessor
+4.2 Tokens recognized in #define directives
+-------------------------------------------
+The following tokens are recognized in the replacement-list of a #define
+directive and handled by the preprocessor during expansion:
+    - # (stringify operator)
+    - ## (token concatenation operator)
+    - Any previously #defined macro name
+    - Any argument name in a function-like macro
+    - __VA_ARGS__  in the replacement-list of a function-like macro
+                   that uses the ellipsis notation in the parameters.
+    - __VA_OPT__   in the replacement-list of a function-like macro
+                   that use the ellipsis notation in the parameters.
+
+Any other text in the replacement-list is preserved unchanged during macro
+expansion, and may for example include any tokens valid in Fortran or C.
 
 
 4.3 Operators accepted in #if and #elif expressions
@@ -215,10 +223,6 @@ via #include.
     __DATE__
     __TIME__
     __STDF__
-    __VA_ARGS__  in the replacement-list of a function-like macro
-                 that uses the ellipsis notation in the parameters.
-    __VA_OPT__   in the replacement-list of a function-like macro
-                 that use the ellipsis notation in the parameters.
 
 __STDF__ is an analog to __STDC__ in C and __cplusplus in C++. Its
 primary role is to provide preprocessor-visible and vendor-independent


### PR DESCRIPTION
CPP _recognizes_ and processes certain tokens (`#`, `##`, `__VA_ARGS__`, `__VA_OPT__`, and FLM arguments), in the replacement-list of macro. But it never "rejects" anything whatsoever, any unrecognized tokens are just passed through uninterpreted to expansion. So it's not correct to talk about "accepting tokens" in that context.

`__VA_ARGS__`, `__VA_OPT__` really belong in this section instead of "4.4 Macros defined by the preprocessor" where they were misleadingly placed before, so move them.