### PR TITLE
Remove obsolete parenthetical

### DIFF
--- a/drafts/25-114.txt
+++ b/drafts/25-114.txt
@@ -142,7 +142,8 @@ Comment handling:
        (processor-specific, such as '!$omp', or '!$acc', or others).
 
 Constant expressions in #if and #elif:
-    1. Expressions in #if and #elif directives allow operators from CPP.
+    1. Expressions in #if and #elif directives allow most operators
+       from CPP (see section 4.3 below).
     2. Expressions in #if and #elif directives must be integer constant
        expressions as specified for CPP and evaluate to INTEGER values.
        As in CPP, zero values are treated as 'false'. Non-zero values

--- a/drafts/25-114.txt
+++ b/drafts/25-114.txt
@@ -144,9 +144,9 @@ Comment handling:
 Constant expressions in #if and #elif:
     1. Expressions in #if and #elif directives allow operators from CPP.
     2. Expressions in #if and #elif directives must be integer constant
-       expressions as specified for CPP (with the extensions described
-       below), and evaluate to INTEGER values. As in CPP, zero values
-       are treated as 'false'. Non-zero values are treated as 'true'.
+       expressions as specified for CPP and evaluate to INTEGER values.
+       As in CPP, zero values are treated as 'false'. Non-zero values
+       are treated as 'true'.
     3. Any undefined identifiers that remain after macro expansion
        (including those lexically identical to keywords or intrinsics)
        are treated as zero, as in CPP.


### PR DESCRIPTION
Remove a left-over parenthetical statement, which was rendered obsolete with the merge of PR #39.

FPP expressions for #if and #elif no longer accept a superset of operators accepted by CPP (it's now a proper subset).