### PR TITLE
Add initial (very rough) outline for specifications paper

### DIFF
--- a/drafts/25-xxx-specifications.txt
+++ b/drafts/25-xxx-specifications.txt
@@ -146,7 +146,9 @@ co02. '/*' ... '*/' comments on directive lines shall extend past a
 co03. '/*' ... '*/' comments on directive lines are replaced by a
       single space, as specified in C 2023 5.1.1.2 bullet 3.
 
-co04. Directive lines shall not contain Fortran '!' style comments.
+co04. In a directive line, the '!' character is not interpreted as introducing 
+      a Fortran-style comment, and neither the `!` character nor any subsequent
+      text are removed by the preprocessor.
 
 co05. Directive lines (by definition) cannot contain Fortran
       fixed-form 'C' or '*' style comments.

--- a/drafts/25-xxx-specifications.txt
+++ b/drafts/25-xxx-specifications.txt
@@ -38,8 +38,8 @@ handling, and tokenization for the preprocessor.)
 -----------
 
 li00. The Fortran preprocessor recognizes three distinct types of lines:
-      Fortran source fragments, Fortran comment lines, and preprocessing
-      directives.
+      preprocessing directives (and continuation lines thereof), 
+      Fortran comment lines, and Fortran source fragments.
 
 li10. Fortran comment lines are defined as in 25-007 6.2.2.3 and
       6.2.3.2.

--- a/drafts/25-xxx-specifications.txt
+++ b/drafts/25-xxx-specifications.txt
@@ -41,12 +41,10 @@ li00. The Fortran preprocessor recognizes three distinct types of lines:
       preprocessing directives (and continuation lines thereof), 
       Fortran comment lines, and Fortran source fragments.
 
-li10. Fortran comment lines are defined as in 25-007 6.2.2.3 and
-      6.2.3.2.
-
-li20. Lines that are not Fortran comment lines that have a '#'
-      character as the first non-blank character of the line are
-      directive lines, as required by C 2023 6.10.1 paragraph 2.
+li10. A line that has a '#'
+      character as the first non-blank character of the line is a
+      directive line (as required by C 2023 6.10.1 paragraph 2),
+      except when otherwise specified by the next two rules.
 
 li21. In fixed-form input files, a '#' in column 6 of a non-comment
       line does not introduce a directive line.

--- a/drafts/25-xxx-specifications.txt
+++ b/drafts/25-xxx-specifications.txt
@@ -65,8 +65,9 @@ li23. The maximum length of a preprocessor directive (including
 li24. A non-empty source file shall not end with a '\' followed
       immediately by a new-line as required in C 2023 5.1.1.2 bullet 2.
 
-li30. Fortran source fragments are those lines that are not Fortran
-      comment lines nor preprocessor directive lines.
+li30. Fortran source fragments are those lines that are neither 
+      preprocessor directive lines (or continuations thereof)
+      nor Fortran comment lines.
 
 li21. In a fixed-form Fortran fragment, a '#' in column 6 does not make
       the line a directive line; it is a Fortran source fragment.

--- a/drafts/25-xxx-specifications.txt
+++ b/drafts/25-xxx-specifications.txt
@@ -114,7 +114,7 @@ cs03. Preprocessor-defined macro names are case-sensitive.
 2.1.3 Significance of whitespace
 --------------------------------
 
-ws01. The whitespace characters blank and the tab character may appear
+ws01. The whitespace characters blank and horizontal tab character may appear
       on directive lines.
 
 ws03. Whitespace characters are significant in determining token

--- a/drafts/25-xxx-specifications.txt
+++ b/drafts/25-xxx-specifications.txt
@@ -107,7 +107,7 @@ cs01. Directive names are case-sensitive and recognized in lower-case.
 cs02. Macro names and function-like macro argument names are
       case-sensitive.
 
-cs03. Preprocessor-defined macro names are case sensitive.
+cs03. Preprocessor-defined macro names are case-sensitive.
 
 
 

--- a/drafts/25-xxx-specifications.txt
+++ b/drafts/25-xxx-specifications.txt
@@ -240,7 +240,8 @@ di07. The non-directive directive
 
 4.9 The '#' and '##' operators
 ------------------------------
-
+4.2 The identifiers __VA_ARGS__ and __VA_OPT__
+----------------------------------------------
 
 
 

--- a/drafts/25-xxx-specifications.txt
+++ b/drafts/25-xxx-specifications.txt
@@ -80,7 +80,7 @@ li32. Fortran source fragments may be continued with a continuation
       of a fixed-form line as specified in Fortran 2023 6.3.3.3).
 
       Example 1 (free-form):
-          call subroutine foo(1, 2, &
+          call subroutine_foo(1, 2, &
       #ifdef USE_3
                                     3, &
       #else

--- a/drafts/25-xxx-specifications.txt
+++ b/drafts/25-xxx-specifications.txt
@@ -2,7 +2,7 @@ To: J3                                                         J3/24-148
 From: JoR
 Subject: Formal specifications for the Fortran preprocessor (FPP)
 Date: 2025-March-09
-References: 25-114r2
+References: 25-114r2 Fortran preprocessor requirements
             25-007 Fortran 2023 Interpretation Document
             24-108 Preprocessor directives seen in existing Fortran
                    programs.txt

--- a/drafts/25-xxx-specifications.txt
+++ b/drafts/25-xxx-specifications.txt
@@ -50,8 +50,14 @@ li21. In fixed-form input files, a '#' in column 6 of a non-comment
       line does not introduce a directive line.
 
 li22. A preprocessor directive can be continued with a backslash '\'
-      immediately followed a new-line. The backslash and new-line are
-      deleted.
+      immediately followed by a new-line. The backslash and new-line are
+      deleted, the content of the subsequent line are textually appended
+      to the current directive, and the subsequent line is deleted.
+      This process repeats until the current directive does not end 
+      with a backslash '\' immediately followed by a new-line.
+
+li23. Preprocessor directive continuation processing described by the prior rule is
+      effectively performed before any other processing of the text in affected lines.
 
 li23. The maximum length of a preprocessor directive (including
       continuation text) is one million characters.

--- a/drafts/25-xxx-specifications.txt
+++ b/drafts/25-xxx-specifications.txt
@@ -1,0 +1,491 @@
+To: J3                                                         J3/24-148
+From: JoR
+Subject: Formal specifications for the Fortran preprocessor (FPP)
+Date: 2025-March-09
+References: 25-114r2
+            25-007 Fortran 2023 Interpretation Document
+            24-108 Preprocessor directives seen in existing Fortran
+                   programs.txt
+            24-109 On Fortran awareness in a Fortran preprocessor.txt
+            ISO/IEC 9899:2023 Programming languages -- C
+                   (working draft N3096)
+
+
+1. Introduction
+===============
+
+At its meeting Feb 19, 2025, J3 decided to approve requirements for
+a cpp-like preprocessor for Fortran 202Y (paper 25-114r2).
+
+This is the formal specifications document, revised according to the
+discussion arising from 25-114r2.
+
+Terminology: For the purpose of this specification, the 'preprocessor'
+encompasses any stages of preprocessing of the input text. For didactic
+purposes, that might include additional phases of "preprocessing" that
+help define the expected priorities of preprocessing behaviors. (In past
+discussions, these have included line continuation processing, comment
+handling, and tokenization for the preprocessor.)
+
+
+2. Formal specifications
+========================
+
+2.1 Lexical specifications
+--------------------------
+
+2.1.1 Lines
+-----------
+
+li00. The Fortran preprocessor recognizes three distinct types of lines:
+      Fortran source fragments, Fortran comment lines, and preprocessing
+      directives.
+
+li10. Fortran comment lines are defined as in 25-007 6.2.2.3 and
+      6.2.3.2.
+
+li20. Lines that are not Fortran comment lines that have a '#'
+      character as the first non-blank character of the line are
+      directive lines, as required by C 2023 6.10.1 paragraph 2.
+
+li21. In fixed-form input files, a '#' in column 6 of a non-comment
+      line does not introduce a directive line.
+
+li22. A preprocessor directive can be continued with a backslash '\'
+      immediately followed a new-line. The backslash and new-line are
+      deleted.
+
+li23. The maximum length of a preprocessor directive (including
+      continuation text) is one million characters.
+
+li24. A non-empty source file shall not end with a '\' followed
+      immediately by a new-line as required in C 2023 5.1.1.2 bullet 2.
+
+li30. Fortran source fragments are those lines that are not Fortran
+      comment lines nor preprocessor directive lines.
+
+li21. In a fixed-form Fortran fragment, a '#' in column 6 does not make
+      the line a directive line; it is a Fortran source fragment.
+
+
+
+li31. Text on fixed-form Fortran source fragments is ignored beyond
+      column 72.
+
+li32. Fortran source fragments may be continued with a continuation
+      ('&' at the end of a free-form line as specified in Fortran 2023
+      6.3.2.4, or with a non-blank, non-zero character in column 6
+      of a fixed-form line as specified in Fortran 2023 6.3.3.3).
+
+      Example 1 (free-form):
+          call subroutine foo(1, 2, &
+      #ifdef USE_3
+                                    3, &
+      #else
+                                    666, &
+      #endif
+                                    .true.)
+
+      Example 2 (fixed-form):
+            call subroutine foo(1, 2,
+      #ifdef USE_3
+           1                       3,
+      #else
+           1                       666,
+      #endif
+           2                       .true.)
+
+
+
+2.1.2 Case sensitivity of identifiers
+-------------------------------------
+
+cs01. Directive names are case-sensitive and recognized in lower-case.
+
+cs02. Macro names and function-like macro argument names are
+      case-sensitive.
+
+cs03. Preprocessor-defined macro names are case sensitive.
+
+
+
+2.1.3 Significance of whitespace
+--------------------------------
+
+ws01. The whitespace characters blank and the tab character may appear
+      on directive lines.
+
+ws03. Whitespace characters are significant in determining token
+      boundaries in preprocessor directive lines.
+
+ws02. Whitespace characters are significant in determining token
+      boundaries in fixed-form and free-fort Fortran source fragments.
+
+ws03. Whitespace characters are significant in determining token
+      boundaries in fixed-form and free-fort Fortran comment lines.
+
+ws04. In fixed-form input, macro names are not recognized as such when
+      spaces are inserted into their invocations.
+
+
+2.2 Comments
+------------
+
+co01. Directive lines may contain C-style '/*' ... '*/' comments.
+
+co02. Directive lines shall not contain C style '//' comments.
+
+co02. '/*' ... '*/' comments on directive lines shall extend past a
+      new-line only if the line ends in '\' new-line, indicating a
+      continuation line. (Maybe controversial)
+
+co03. '/*' ... '*/' comments on directive lines are replaced by a
+      single space, as specified in C 2023 5.1.1.2 bullet 3.
+
+co04. Directive lines shall not contain Fortran '!' style comments.
+
+co05. Directive lines (by definition) cannot contain Fortran
+      fixed-form 'C' or '*' style comments.
+
+
+2.4 Token lexicon
+-----------------
+[gak: List the character sequences that are recognized as separate tokens
+on directives and in Fortran source fragments. This should include
+Fortran identifiers, Fortran numeric constants, Fortran character
+constants, the Fortran operators, and the C operators used to construct
+constant-integer-expression.]
+
+
+
+3 #-Directives
+==============
+
+di01. The '#define' macro directive
+
+di02. The '#define' function-like macro directive
+
+di03. The '#undef' directive
+
+di04. The '#include' directive
+
+di03. The '#if', '#ifdef', '#ifndef', '#elif', '#elifdef',
+      '#elifndef', '#else', '#endif' directive collective
+
+di04. The '#error' and '#warning' directives
+
+di05. The '#line' directive
+
+di06. The '#pragma' directive
+
+di07. The non-directive directive
+
+
+
+
+3.1 The '#define' macro directive
+---------------------------------
+
+
+3.2 The '#define' function-like macro directive
+-----------------------------------------------
+
+
+3.3 The '#undef' directive
+--------------------------
+
+
+
+3.4 The '#include' directive
+----------------------------
+
+
+3.3 The '#if', '#ifdef', '#ifndef', '#elif', '#elifdef',
+      '#elifndef', '#else', '#endif' directive collective
+---------------------------------------------------------
+
+
+3.4 The '#error' and '#warning' directives
+------------------------------------------
+
+
+3.5 The '#line' directive
+-------------------------
+
+
+3.6 The '#pragma' directive
+---------------------------
+
+
+3.7 The non-directive directive
+-------------------------------
+
+
+
+
+4 Macro recognition and expansion
+---------------------------------
+
+
+
+4.8 The 'defined' operator
+--------------------------
+
+
+4.9 The '#' and '##' operators
+------------------------------
+
+
+
+
+
+
+5 Expressions allowed in #if and #elif directives
+=================================================
+
+
+
+6 Expression evaluation in #if and #elif directives
+===================================================
+
+
+
+7 Predefined macros
+===================
+
+
+7.1 __LINE__
+------------
+
+
+7.2 __FILE__
+------------
+
+
+7.3 __DATE__
+------------
+
+
+7.4 __TIME__
+------------
+
+
+7.5 __STDF__
+------------
+__STDF__ is an analog to __STDC__ in C and __cplusplus in C++. Its
+primary role is to provide preprocessor-visible and vendor-independent
+identification of the underlying target language (i.e., "the processor
+is Fortran"), which enables one to write multi-language header files
+with conditional compilation based on language.
+
+st01. The predefined value of __STDF__ is 1.
+
+
+
+8 Output of the preprocessor
+============================
+[gak: What we want to say about the specifics of the output, presumably
+as a token stream, not necessarily as a character stream.]
+
+
+
+
+=======================================================================
+Raw material from other sources, to incorporate into the above sections
+=======================================================================
+[gak: Just for my notes, collecting as much as I can that already exists.]
+
+
+======================================================================
+From Flang Preprocessing.md  [[ws:gh-llvm/llvm-project/flang/docs/Preprocessing.md][Preprocessing.md]]:
+* Text is rescanned after expansion of macros and arguments.
+* Macros are not expanded within quoted character literals or
+  quoted FORMAT edit descriptors.
+* Macro expansion occurs before any effective token pasting via
+  fixed form space removal.
+* After `#define FALSE TRUE`, `.FALSE.` is replaced by `.TRUE.`;
+  i.e., tokenization does not hide the names of operators or logical
+  constants.
+* `#define KWM c` allows the use of `KWM` in column 1 as a fixed form
+  comment line indicator.
+
+## Behavior that is not consistent over all extant compilers but which probably should be uncontroversial:
+
+* Invoked macro names can straddle a Fortran line continuation.
+* ... unless implicit fixed form card padding intervenes; i.e.,
+  in fixed form, a continued macro name has to be split at column
+  72 (or 132).
+* Comment lines may appear with continuations in a split macro names.
+* Function-like macro invocations can straddle a Fortran fixed form line
+  continuation between the name and the left parenthesis, and comment and
+  directive lines can be there too.
+* Function-like macro invocations can straddle a Fortran fixed form line
+  continuation between the parentheses, and comment lines can be there too.
+* Macros are not expanded within Hollerith constants or Hollerith
+  FORMAT edit descriptors.
+* Token pasting with `##` works in function-like macros.
+* Argument stringification with `#` works in function-like macros.
+* Directives can be capitalized (e.g., `#DEFINE`) in fixed form.
+* Fixed form clipping after column 72 or 132 is done before macro expansion,
+  not after.
+* C-like line continuation with backslash-newline can appear in the name of
+  a keyword-like macro definition.
+* If `#` is in column 6 in fixed form, it's a continuation marker, not a
+  directive indicator.
+* `#define KWM !` allows KWM to signal a comment.
+
+## Judgment calls, where precedents are unclear:
+
+* Expressions in `#if` and `#elif` should support both Fortran and C
+  operators; e.g., `#if 2 .LT. 3` should work.
+* If a function-like macro does not close its parentheses, line
+  continuation should be assumed.
+  This includes the case of a keyword-like macro that expands to
+  the name of a function-like macro.
+* ... However, the leading parenthesis has to be on the same line as
+  the name of the function-like macro, or on a continuation line thereof.
+* And no macro definition prior to that point can be allowed to have
+  unbalanced parentheses in its replacement text.
+  When that happens, it's possible to have false positive cases
+  causing implicit line continuations that break real code.
+* If macros expand to text containing `&`, it doesn't work as a free form
+  line continuation marker.
+* `#define c 1` does not allow a `c` in column 1 to be used as a label
+  in fixed form, rather than as a comment line indicator.
+* IBM claims to be ISO C compliant and therefore recognizes trigraph sequences.
+* Fortran comments in macro actual arguments should be respected, on
+  the principle that a macro call should work like a function reference.
+* If a `#define` or `#undef` directive appears among continuation
+  lines, it may or may not affect text in the continued statement that
+  appeared before the directive.
+* A backslash at the end of a free form source line is a continuation
+  marker, with no space skipping or special handling of a leading `&`
+  on the next line.
+
+## Behavior that few compilers properly support (or none), but should:
+
+* A macro invocation can straddle free form continuation lines in all of their
+  forms, with continuation allowed in the name, before the arguments, and
+  within the arguments.
+* Directives can be capitalized in free form, too.
+* `__VA_ARGS__` and `__VA_OPT__` work in variadic function-like macros.
+
+## In short, a Fortran preprocessor should work as if:
+
+1. Fixed form lines are padded up to column 72 (or 132) and clipped thereafter.
+2. Fortran comments are removed.
+3. C-style line continuations are processed in preprocessing directives.
+4. C old-style comments are removed from directives.
+5. Fortran line continuations are processed (outside preprocessing directives).
+   Line continuation rules depend on source form.
+   Comment lines that are enabled compiler directives have their line
+   continuations processed.
+   Conditional compilation preprocessing directives (e.g., `#if`) may be
+   appear among continuation lines, and have their usual effects upon them.
+6. Other preprocessing directives are processed and macros expanded.
+   Along the way, Fortran `INCLUDE` lines and preprocessor `#include` directives
+   are expanded, and all these steps applied recursively to the introduced text.
+7. Any Fortran comments created by macro replacement are removed.
+
+Steps 5 and 6 are interleaved with respect to the preprocessing state.
+Conditional compilation preprocessing directives always reflect only the macro
+definition state produced by the active `#define` and `#undef` preprocessing directives
+that precede them.
+
+
+======================================================================
+From assert@BerkeleyLab README.md  [[ws:gg-fortran-examples/assert@BerkeleyLab/README.md][README.md]]
+#### Line length limit
+
+Up to and including the Fortran 2018 language standard, compilers were only
+required to support up to 132 characters per free-form source line.
+Preprocessor macro invocations are always expanded to a single line during
+compilation, so when passing non-trivial arguments to macros including
+`call_assert*` it becomes easy for the expansion to exceed this line length
+limit. This can result in compile-time errors like the following from gfortran:
+
+```
+Error: Line truncated at (1) [-Werror=line-truncation]
+```
+
+Some compilers offer a command-line argument that can be used to workaround this legacy limit, e.g.,:
+
+* `gfortran -ffree-line-length-0` aka `gfortran -ffree-line-length-none`
+
+When using `fpm`, one can pass such a flag to the compiler using the `fpm --flag` option, e.g.,:
+
+```shell
+$ fpm test --profile release --flag -ffree-line-length-0
+```
+
+Thankfully Fortran 2023 raised this obsolescent line limit to 10,000
+characters, so by using newer compilers you might never encounter this problem.
+In the case of gfortran, this appears to have been resolved by default starting in release 14.1.0.
+
+#### Line breaks in macro invocations
+
+The preprocessor is not currently specified by any Fortran standard, and
+as of 2024 its operation differs in subtle ways between compilers.
+One way in which compilers differ is how macro invocations can safely be broken
+across multiple lines.
+
+For example, gfortran and flang-new both accept backslash `\` continuation
+character for line-breaks in a macro invocation:
+
+```fortran
+! OK for flang-new and gfortran
+call_assert_diagnose( computed_checksum == expected_checksum, \
+                      "Checksum mismatch failure!", \
+                      expected_checksum )
+```
+
+Whereas Cray Fortran wants `&` line continuation characters, even inside
+a macro invocation:
+
+```fortran
+! OK for Cray Fortran
+call_assert_diagnose( computed_checksum == expected_checksum, &
+                      "Checksum mismatch failure!", &
+                      expected_checksum )
+```
+
+There appears to be no syntax acceptable to all compilers, so when writing
+portable code it's probably best to avoid line breaks inside a macro invocation.
+
+
+#### Comments in macro invocations
+
+Fortran does not support comments with an end delimiter,
+only to-end-of-line comments.  As such, there is no portable way to safely insert a
+Fortran comment into the middle of a macro invocation.  For example, the
+following seemingly reasonable code results in a syntax error
+after macro expansion (on gfortran and flang-new):
+
+```fortran
+! INCORRECT: cannot use Fortran comments inside macro invocation
+call_assert_diagnose( computed_checksum == expected_checksum, ! ensured since version 3.14
+                      "Checksum mismatch failure!",           ! TODO: write a better message here
+                      computed_checksum )
+```
+
+Depending on your compiler it *might* be possible to use a C-style block
+comment (because they are often removed by the preprocessor), for example with
+gfortran one can instead write the following:
+
+```fortran
+call_assert_diagnose( computed_checksum == expected_checksum, /* ensured since version 3.14 */ \
+                      "Checksum mismatch failure!",           /* TODO: write a better message here */ \
+                      computed_checksum )
+```
+
+However that capability might not be portable to other Fortran compilers.
+When in doubt, one can always move the comment outside the macro invocation:
+
+```fortran
+! assert a property ensured since version 3.14
+call_assert_diagnose( computed_checksum == expected_checksum, \
+                      "Checksum mismatch failure!",           \
+                      computed_checksum ) ! TODO: write a better message above
+```
+
+LocalWords:  ffree Werror md ARGS KWM STDF cplusplus STDC elifdef

--- a/drafts/25-xxx-specifications.txt
+++ b/drafts/25-xxx-specifications.txt
@@ -121,10 +121,12 @@ ws03. Whitespace characters are significant in determining token
       boundaries in preprocessor directive lines.
 
 ws02. Whitespace characters are significant in determining token
-      boundaries in fixed-form and free-fort Fortran source fragments.
+      boundaries for the purposes of recognizing macro names, 
+      in both fixed-form and free-form Fortran source fragments.
 
 ws03. Whitespace characters are significant in determining token
-      boundaries in fixed-form and free-fort Fortran comment lines.
+      boundaries for the purposes of recognizing macro names, 
+      in both fixed-form and free-form Fortran comment lines.
 
 ws04. In fixed-form input, macro names are not recognized as such when
       spaces are inserted into their invocations.

--- a/drafts/25-xxx-specifications.txt
+++ b/drafts/25-xxx-specifications.txt
@@ -38,7 +38,7 @@ handling, and tokenization for the preprocessor.)
 -----------
 
 li00. The Fortran preprocessor recognizes three distinct types of lines:
-      preprocessing directives (and continuation lines thereof), 
+      preprocessing directives (and continuation lines thereof),
       Fortran comment lines, and Fortran source fragments.
 
 li10. A line that has a '#'
@@ -53,7 +53,7 @@ li22. A preprocessor directive can be continued with a backslash '\'
       immediately followed by a new-line. The backslash and new-line are
       deleted, the content of the subsequent line are textually appended
       to the current directive, and the subsequent line is deleted.
-      This process repeats until the current directive does not end 
+      This process repeats until the current directive does not end
       with a backslash '\' immediately followed by a new-line.
 
 li23. Preprocessor directive continuation processing described by the prior rule is
@@ -65,7 +65,7 @@ li23. The maximum length of a preprocessor directive (including
 li24. A non-empty source file shall not end with a '\' followed
       immediately by a new-line as required in C 2023 5.1.1.2 bullet 2.
 
-li30. Fortran source fragments are those lines that are neither 
+li30. Fortran source fragments are those lines that are neither
       preprocessor directive lines (or continuations thereof)
       nor Fortran comment lines.
 
@@ -121,11 +121,11 @@ ws03. Whitespace characters are significant in determining token
       boundaries in preprocessor directive lines.
 
 ws02. Whitespace characters are significant in determining token
-      boundaries for the purposes of recognizing macro names, 
+      boundaries for the purposes of recognizing macro names,
       in both fixed-form and free-form Fortran source fragments.
 
 ws03. Whitespace characters are significant in determining token
-      boundaries for the purposes of recognizing macro names, 
+      boundaries for the purposes of recognizing macro names,
       in both fixed-form and free-form Fortran comment lines.
 
 ws04. In fixed-form input, macro names are not recognized as such when
@@ -146,7 +146,7 @@ co02. '/*' ... '*/' comments on directive lines shall extend past a
 co03. '/*' ... '*/' comments on directive lines are replaced by a
       single space, as specified in C 2023 5.1.1.2 bullet 3.
 
-co04. In a directive line, the '!' character is not interpreted as introducing 
+co04. In a directive line, the '!' character is not interpreted as introducing
       a Fortran-style comment, and neither the `!` character nor any subsequent
       text are removed by the preprocessor.
 
@@ -292,206 +292,3 @@ st01. The predefined value of __STDF__ is 1.
 ============================
 [gak: What we want to say about the specifics of the output, presumably
 as a token stream, not necessarily as a character stream.]
-
-
-
-
-=======================================================================
-Raw material from other sources, to incorporate into the above sections
-=======================================================================
-[gak: Just for my notes, collecting as much as I can that already exists.]
-
-
-======================================================================
-From Flang Preprocessing.md  [[ws:gh-llvm/llvm-project/flang/docs/Preprocessing.md][Preprocessing.md]]:
-* Text is rescanned after expansion of macros and arguments.
-* Macros are not expanded within quoted character literals or
-  quoted FORMAT edit descriptors.
-* Macro expansion occurs before any effective token pasting via
-  fixed form space removal.
-* After `#define FALSE TRUE`, `.FALSE.` is replaced by `.TRUE.`;
-  i.e., tokenization does not hide the names of operators or logical
-  constants.
-* `#define KWM c` allows the use of `KWM` in column 1 as a fixed form
-  comment line indicator.
-
-## Behavior that is not consistent over all extant compilers but which probably should be uncontroversial:
-
-* Invoked macro names can straddle a Fortran line continuation.
-* ... unless implicit fixed form card padding intervenes; i.e.,
-  in fixed form, a continued macro name has to be split at column
-  72 (or 132).
-* Comment lines may appear with continuations in a split macro names.
-* Function-like macro invocations can straddle a Fortran fixed form line
-  continuation between the name and the left parenthesis, and comment and
-  directive lines can be there too.
-* Function-like macro invocations can straddle a Fortran fixed form line
-  continuation between the parentheses, and comment lines can be there too.
-* Macros are not expanded within Hollerith constants or Hollerith
-  FORMAT edit descriptors.
-* Token pasting with `##` works in function-like macros.
-* Argument stringification with `#` works in function-like macros.
-* Directives can be capitalized (e.g., `#DEFINE`) in fixed form.
-* Fixed form clipping after column 72 or 132 is done before macro expansion,
-  not after.
-* C-like line continuation with backslash-newline can appear in the name of
-  a keyword-like macro definition.
-* If `#` is in column 6 in fixed form, it's a continuation marker, not a
-  directive indicator.
-* `#define KWM !` allows KWM to signal a comment.
-
-## Judgment calls, where precedents are unclear:
-
-* Expressions in `#if` and `#elif` should support both Fortran and C
-  operators; e.g., `#if 2 .LT. 3` should work.
-* If a function-like macro does not close its parentheses, line
-  continuation should be assumed.
-  This includes the case of a keyword-like macro that expands to
-  the name of a function-like macro.
-* ... However, the leading parenthesis has to be on the same line as
-  the name of the function-like macro, or on a continuation line thereof.
-* And no macro definition prior to that point can be allowed to have
-  unbalanced parentheses in its replacement text.
-  When that happens, it's possible to have false positive cases
-  causing implicit line continuations that break real code.
-* If macros expand to text containing `&`, it doesn't work as a free form
-  line continuation marker.
-* `#define c 1` does not allow a `c` in column 1 to be used as a label
-  in fixed form, rather than as a comment line indicator.
-* IBM claims to be ISO C compliant and therefore recognizes trigraph sequences.
-* Fortran comments in macro actual arguments should be respected, on
-  the principle that a macro call should work like a function reference.
-* If a `#define` or `#undef` directive appears among continuation
-  lines, it may or may not affect text in the continued statement that
-  appeared before the directive.
-* A backslash at the end of a free form source line is a continuation
-  marker, with no space skipping or special handling of a leading `&`
-  on the next line.
-
-## Behavior that few compilers properly support (or none), but should:
-
-* A macro invocation can straddle free form continuation lines in all of their
-  forms, with continuation allowed in the name, before the arguments, and
-  within the arguments.
-* Directives can be capitalized in free form, too.
-* `__VA_ARGS__` and `__VA_OPT__` work in variadic function-like macros.
-
-## In short, a Fortran preprocessor should work as if:
-
-1. Fixed form lines are padded up to column 72 (or 132) and clipped thereafter.
-2. Fortran comments are removed.
-3. C-style line continuations are processed in preprocessing directives.
-4. C old-style comments are removed from directives.
-5. Fortran line continuations are processed (outside preprocessing directives).
-   Line continuation rules depend on source form.
-   Comment lines that are enabled compiler directives have their line
-   continuations processed.
-   Conditional compilation preprocessing directives (e.g., `#if`) may be
-   appear among continuation lines, and have their usual effects upon them.
-6. Other preprocessing directives are processed and macros expanded.
-   Along the way, Fortran `INCLUDE` lines and preprocessor `#include` directives
-   are expanded, and all these steps applied recursively to the introduced text.
-7. Any Fortran comments created by macro replacement are removed.
-
-Steps 5 and 6 are interleaved with respect to the preprocessing state.
-Conditional compilation preprocessing directives always reflect only the macro
-definition state produced by the active `#define` and `#undef` preprocessing directives
-that precede them.
-
-
-======================================================================
-From assert@BerkeleyLab README.md  [[ws:gg-fortran-examples/assert@BerkeleyLab/README.md][README.md]]
-#### Line length limit
-
-Up to and including the Fortran 2018 language standard, compilers were only
-required to support up to 132 characters per free-form source line.
-Preprocessor macro invocations are always expanded to a single line during
-compilation, so when passing non-trivial arguments to macros including
-`call_assert*` it becomes easy for the expansion to exceed this line length
-limit. This can result in compile-time errors like the following from gfortran:
-
-```
-Error: Line truncated at (1) [-Werror=line-truncation]
-```
-
-Some compilers offer a command-line argument that can be used to workaround this legacy limit, e.g.,:
-
-* `gfortran -ffree-line-length-0` aka `gfortran -ffree-line-length-none`
-
-When using `fpm`, one can pass such a flag to the compiler using the `fpm --flag` option, e.g.,:
-
-```shell
-$ fpm test --profile release --flag -ffree-line-length-0
-```
-
-Thankfully Fortran 2023 raised this obsolescent line limit to 10,000
-characters, so by using newer compilers you might never encounter this problem.
-In the case of gfortran, this appears to have been resolved by default starting in release 14.1.0.
-
-#### Line breaks in macro invocations
-
-The preprocessor is not currently specified by any Fortran standard, and
-as of 2024 its operation differs in subtle ways between compilers.
-One way in which compilers differ is how macro invocations can safely be broken
-across multiple lines.
-
-For example, gfortran and flang-new both accept backslash `\` continuation
-character for line-breaks in a macro invocation:
-
-```fortran
-! OK for flang-new and gfortran
-call_assert_diagnose( computed_checksum == expected_checksum, \
-                      "Checksum mismatch failure!", \
-                      expected_checksum )
-```
-
-Whereas Cray Fortran wants `&` line continuation characters, even inside
-a macro invocation:
-
-```fortran
-! OK for Cray Fortran
-call_assert_diagnose( computed_checksum == expected_checksum, &
-                      "Checksum mismatch failure!", &
-                      expected_checksum )
-```
-
-There appears to be no syntax acceptable to all compilers, so when writing
-portable code it's probably best to avoid line breaks inside a macro invocation.
-
-
-#### Comments in macro invocations
-
-Fortran does not support comments with an end delimiter,
-only to-end-of-line comments.  As such, there is no portable way to safely insert a
-Fortran comment into the middle of a macro invocation.  For example, the
-following seemingly reasonable code results in a syntax error
-after macro expansion (on gfortran and flang-new):
-
-```fortran
-! INCORRECT: cannot use Fortran comments inside macro invocation
-call_assert_diagnose( computed_checksum == expected_checksum, ! ensured since version 3.14
-                      "Checksum mismatch failure!",           ! TODO: write a better message here
-                      computed_checksum )
-```
-
-Depending on your compiler it *might* be possible to use a C-style block
-comment (because they are often removed by the preprocessor), for example with
-gfortran one can instead write the following:
-
-```fortran
-call_assert_diagnose( computed_checksum == expected_checksum, /* ensured since version 3.14 */ \
-                      "Checksum mismatch failure!",           /* TODO: write a better message here */ \
-                      computed_checksum )
-```
-
-However that capability might not be portable to other Fortran compilers.
-When in doubt, one can always move the comment outside the macro invocation:
-
-```fortran
-! assert a property ensured since version 3.14
-call_assert_diagnose( computed_checksum == expected_checksum, \
-                      "Checksum mismatch failure!",           \
-                      computed_checksum ) ! TODO: write a better message above
-```
-
-LocalWords:  ffree Werror md ARGS KWM STDF cplusplus STDC elifdef

--- a/drafts/25-xxx-specifications.txt
+++ b/drafts/25-xxx-specifications.txt
@@ -234,9 +234,6 @@ di07. The non-directive directive
 
 
 
-4.8 The 'defined' operator
---------------------------
-
 
 4.9 The '#' and '##' operators
 ------------------------------

--- a/drafts/25-xxx-specifications.txt
+++ b/drafts/25-xxx-specifications.txt
@@ -89,7 +89,7 @@ li32. Fortran source fragments may be continued with a continuation
                                     .true.)
 
       Example 2 (fixed-form):
-            call subroutine foo(1, 2,
+            call subroutine_foo(1, 2,
       #ifdef USE_3
            1                       3,
       #else

--- a/drafts/25-xxx-specifications.txt
+++ b/drafts/25-xxx-specifications.txt
@@ -176,7 +176,7 @@ di03. The '#undef' directive
 di04. The '#include' directive
 
 di03. The '#if', '#ifdef', '#ifndef', '#elif', '#elifdef',
-      '#elifndef', '#else', '#endif' directive collective
+      '#elifndef', '#else', '#endif' directives
 
 di04. The '#error' and '#warning' directives
 

--- a/drafts/25-xxx-specifications.txt
+++ b/drafts/25-xxx-specifications.txt
@@ -69,9 +69,6 @@ li30. Fortran source fragments are those lines that are neither
       preprocessor directive lines (or continuations thereof)
       nor Fortran comment lines.
 
-li21. In a fixed-form Fortran fragment, a '#' in column 6 does not make
-      the line a directive line; it is a Fortran source fragment.
-
 
 
 li31. Text on fixed-form Fortran source fragments is ignored beyond

--- a/drafts/25-xxx-specifications.txt
+++ b/drafts/25-xxx-specifications.txt
@@ -247,7 +247,8 @@ di07. The non-directive directive
 5 Expressions allowed in #if and #elif directives
 =================================================
 
-
+5.1 The 'defined' operator
+--------------------------
 
 6 Expression evaluation in #if and #elif directives
 ===================================================

--- a/drafts/25-xxx-specifications.txt
+++ b/drafts/25-xxx-specifications.txt
@@ -207,7 +207,7 @@ di07. The non-directive directive
 
 
 3.3 The '#if', '#ifdef', '#ifndef', '#elif', '#elifdef',
-      '#elifndef', '#else', '#endif' directive collective
+      '#elifndef', '#else', '#endif' directives
 ---------------------------------------------------------
 
 


### PR DESCRIPTION
Many subsections are not filled in yet.
At the end is a bunch of raw material that we
need to consider adding to the earlier sections.
This raw material comes from 25-114r2, Peter Klausler's Preprocessing.md in Flang, and Berkely Lab's
assert library.There are probably other places
we need to pull from as well.