### PR TITLE
Rough draft of Section 3.5 conditionals: #if, #elif, etc.

### DIFF
--- a/drafts/25-xxx-specifications.txt
+++ b/drafts/25-xxx-specifications.txt
@@ -494,8 +494,8 @@ ix12. In the descriptions below, <group> constructs may be "skipped".
         - Conditional directives within the <group> are recognized only
           to maintain proper nesting of conditional directives.
         - No nested directives in the <group> are processed.
-        - No Fortran comment lines or source lines in the <group>
-          are examined for macro expansion.
+        - No macro expansion takes place in directive lines, Fortran
+          comment lines or source lines in the <group>.
         - No skipped lines of any kind in the <group> are made available
           subsequent processing by the processor.
 

--- a/drafts/25-xxx-specifications.txt
+++ b/drafts/25-xxx-specifications.txt
@@ -414,20 +414,132 @@ in28. Unlike INCLUDE lines (see the section on "INCLUDE lines"),
       the #include directive is not prohibited from including the
       same source file at a deeper level of nesting.
 
+
 3.5 The '#if', '#ifdef', '#ifndef', '#elif', '#elifdef',
-      '#elifndef', '#else', '#endif' directives
+      '#elifndef', '#else', '#endif' conditional directives
 ---------------------------------------------------------
 
-Example syntax:
+Example syntax (extra spacing for illustration purposes only):
+    General form:
+        <if-head>  <lines>                        #endif EOL
+        <if-head>  <lines>  <if-elif>             #endif EOL
+        <if-head>  <lines>  <if-elif>  <if-else>  #endif EOL
 
+    Where:
+        <if-head> is one of:
+            #if token-list EOL  <lines>
+            #ifdef ID EOL       <lines>
+            #ifndef ID EOL      <lines>
+
+        <if-elif> is zero or more of:
+            #elif     token-list EOL  <lines>
+            #elifdef  ID EOL          <lines>
+            #elifndef ID EOL          <lines>
+
+        <if-else> is zero or one of:
+            #else EOL  <lines>
+
+        <lines> are zero or more of:
+            directive lines
+            Fortran comment lines
+            Fortran source lines
 
 
 3.5.1 Static semantics specifications
---------------------------------------
+-------------------------------------
+
+if05. A #if, ##ifdef, or #ifndef directive signals the start
+      of a list of conditional directives.
+
+if10: Whitespace must immediately follow the directives tokens
+      'ifdef', 'ifndef', 'elifdef', and 'elifndef' to separate
+      them from the ID tokens.
+
+if15. The list of #elif, #elifdef, and #elifndef directives, and
+      the #else directive (if present) are part of the same list
+      of directives introduced by the #if directive.
+
+if20. The chain of conditional directives ends with the #endif
+      directive.
+
+if25. Within a conditional directive list, a #if, #ifdef, or
+      #endif directive introduces a new list of conditional
+      directives, at a new nesting level, within the enclosing
+      conditional directive list.
+
+if30. The conditional directive lists must properly nest.
+
+if35. As shown in the illustrative syntax, there should be
+      no unmatched #endif directives.
+
+if40. As shown in the illustrative syntax, there should be
+      no more than one #else directive in a list of conditional
+      directives at any nesting level.
 
 
 3.5.2 Evaluation semantics specifications
 -----------------------------------------
+
+
+ix05. The #ifdef and #ifndef macros are evaluated as if
+      they had been written "#if defined(ID)" and
+      "#if !defined(ID)" respectively.
+
+ix10. The #elifdef and #elifndef macros are evaluated as if
+      they had been written "#elif defined(ID)" and "#elif !defined(ID)"
+      respectively.
+
+ix15. The token-lists in #if and #elif are processed as described
+      in the section "Macro recognition and expansion".
+
+ix20. After expansion, the resulting token list in #if and #elif
+      directives must represent a valid integer expression as
+      described in the section "Expressions allowed in #if and
+      #elif directives".
+
+ix25. The resulting token list is parsed and evaluated according
+      to the semantic rules described in section "Expressions allowed
+      in #if and #elif directives".
+
+ix30. If the expression in a #if evaluates to a C true value, the
+      <lines> immediately following the #if participate in preprocessing.
+      They are subject to preprocessing expansion,  substitution, and
+      evaluation of processing directives in the <lines>.
+
+ix40. Further preprocessing when #if evaluates to C true proceeds.
+      Subsequent #elif and #else directives at the same level of
+      nesting are skipped, and do not participate in preprocessing
+      except to be examined for proper nesting of conditional directives.
+
+ix45. If the expression in a #if evaluates to a C false value (zero),
+      the lines immediately following the #if directive are skipped, and
+      examined only to determine nesting of conditionals. No token
+      expansion occurs. No Fortran comment lines or source lines are
+      made available to the processor. Processing continues with
+      processing any #elif directives at the same level of nesting, as
+      described below.
+
+ix50. When the #if expression evaluates to C false, the #elif directives
+      at the same nesting level are evaluated in the order they appear
+      in the source. Those whose expression evaluate to false are
+      skipped in the same manner as when a #if clause evaluates to false.
+
+ix55. When a #elif expression evaluates to C true, the <lines>
+      immediately following the #elif participate in preprocessing
+      just as they do when the expression in a #if evaluates to C true.
+      Subsequent #elif and #else directives at the same nesting
+      level are skipped, as described for #if.
+
+ix60. When no #if expression or #elif expression evaluates to C true
+      and a #else directive is present at the same nesting level,
+      the <lines> between the #else directive and the matching #endif
+      directive are subject to preprocessing, expansion and substitution
+      as they would be in #if true processing.
+
+ix65. When no #if expression or #elif expression evaluates to C true
+      and no #else directive is present at the same nesting level,
+      there are no <lines> in the list of conditional directives
+      subject to preprocessing.
 
 
 3.6 The '#error' and '#warning' directives

--- a/drafts/25-xxx-specifications.txt
+++ b/drafts/25-xxx-specifications.txt
@@ -59,7 +59,7 @@ li17. Preprocessor directive continuation processing described by the prior rule
 li19. The maximum length of a preprocessor directive (including
       continuation text) is one million characters.
 
-li21. A source file that ends with a directive line shall neither end with a '\', 
+li21. A source file that ends with a directive line shall neither end with a '\',
       nor a '\' followed immediately by a new-line (analogously to C 2023 5.1.1.2 bullet 2).
 
 li31. Fortran comment lines are defined as in 25-007 6.3.2.3 and
@@ -177,9 +177,9 @@ Further definition of the recognized tokens is deferred to the upcoming preproce
 
 
 to01. In the definitions of object macros and function-like macros,
-      the replacement list may include any arbitrary sequence of 
+      the replacement list may include any arbitrary sequence of
       characters that doesn't include a new-line. Once tokenized,
-      this for example may include any tokens allowed in Fortran 
+      this for example may include any tokens allowed in Fortran
       source lines, those allowed in C integer expressions,
       and any additional tokens recognized by the processor.
 
@@ -415,7 +415,7 @@ in24. If the file is located, the processor replaces the #include
 in26. A #include directive may appear in an included file, up to a
       processor-defined nesting limit.
 
-in28. Unlike INCLUDE lines (see the section on "INCLUDE lines"), 
+in28. Unlike INCLUDE lines (see the section on "INCLUDE lines"),
       the #include directive is not prohibited from including the
       same source file at a deeper level of nesting.
 
@@ -455,21 +455,21 @@ Example syntax (extra spacing for illustration purposes only):
 3.5.1 Static semantics specifications
 -------------------------------------
 
-if05. A #if, #ifdef, or #ifndef directive signals the start of a list
+if05. A #if, #ifdef, or #ifndef directive signals the start of a chain
       of conditional directives.
 
-if15. The list of #elif, #elifdef, and #elifndef directives, and the
-      #else directive (if present) are part of the same list of
+if15. The chain of #elif, #elifdef, and #elifndef directives, and the
+      #else directive (if present) are part of the same chain of
       directives introduced by the #if directive.
 
 if20. The chain of conditional directives ends with the #endif
       directive.
 
-if25. Within a conditional directive list, a #if, #ifdef, or #ifndef
-      directive introduces a new list of conditional directives, at a new
-      nesting level, within the enclosing conditional directive list.
+if25. Within a conditional directive chain, a #if, #ifdef, or #ifndef
+      directive introduces a new chain of conditional directives, at a new
+      nesting level, within the enclosing conditional directive chain.
 
-if30. The conditional directive lists must properly nest.
+if30. The conditional directive chains must properly nest.
 
 
 
@@ -484,7 +484,7 @@ ix05. The #ifdef and #ifndef directives are evaluated as if they had been
 
 ix10. The #elifdef and #elifndef directives are evaluated as if they had
       been written "#elif defined(ID)" and "#elif !defined(ID)"
-      respectively. (For brevity, the descriptions below 
+      respectively. (For brevity, the descriptions below
       assume this transformation has been made).
 
 ix12. In the descriptions below, <group> constructs may be "skipped".
@@ -509,7 +509,7 @@ ix14. In the descriptions below, <group> constructs that are not
           processor.
 
 ix15. Before evaluating the token-lists in any <if-head> and <if-elif>
-      constructs that are not skipped, macros in the token-lists are 
+      constructs that are not skipped, macros in the token-lists are
       processed as described in the section "Macro recognition and expansion".
 
 ix20. After expansion, the resulting token list in <if-head> and <if-elif>
@@ -609,7 +609,7 @@ li04. The WHOLE_NUMBER shall not exceed 2147483647.
 -----------------------------------------
 
 li20. In both forms, the #line directive causes the processor
-      to behave as if the following sequence of lines begins with a 
+      to behave as if the following sequence of lines begins with a
       presumed line number specified by the WHOLE_NUMBER.
 
 li24. In the second form, the #line directive causes the processor
@@ -742,8 +742,8 @@ The following macro names shall be defined by the processor:
 7.1 __LINE__
 ------------
 
-pm20. `__LINE__` shall be predefined to a WHOLE_NUMBER representing 
-      the presumed line number (within the current source file) 
+pm20. `__LINE__` shall be predefined to a WHOLE_NUMBER representing
+      the presumed line number (within the current source file)
       of the current source line.
 
 7.2 __FILE__
@@ -795,7 +795,7 @@ Appendix A: Divergences from C
 In many ways, the FPP specified by this document adheres to the
 existing practice established by the C preprocessor over the past
 several decades. However FPP semantics also deliberately diverge from
-the analogous behavior of the C preprocessor as specified in C 2023. 
+the analogous behavior of the C preprocessor as specified in C 2023.
 This non-normative section enumerates such deliberate differences,
 as a reference for readers to assist in comparisons.
 
@@ -834,5 +834,3 @@ dfc90. FPP omits the `__has_embed` expression added in C 2023.
 
 [dob: This section may need to be amended as we settle on unresolved
      topics such as _Pragma]
-
-

--- a/drafts/25-xxx-specifications.txt
+++ b/drafts/25-xxx-specifications.txt
@@ -480,7 +480,7 @@ if40. As shown in the illustrative syntax, there should be no more
 -----------------------------------------
 
 
-ix05. The #ifdef and #ifndef macros are evaluated as if they had been
+ix05. The #ifdef and #ifndef directives are evaluated as if they had been
       written "#if defined(ID)" and "#if !defined(ID)" respectively.
       (For brevity, the descriptions of #ifdef and #ifndef directives
       below are omitted, and assume this transformation.)

--- a/drafts/25-xxx-specifications.txt
+++ b/drafts/25-xxx-specifications.txt
@@ -448,7 +448,7 @@ Example syntax (extra spacing for illustration purposes only):
 3.5.1 Static semantics specifications
 -------------------------------------
 
-if05. A #if, ##ifdef, or #ifndef directive signals the start of a list
+if05. A #if, #ifdef, or #ifndef directive signals the start of a list
       of conditional directives.
 
 if10: Whitespace must immediately follow the directives tokens

--- a/drafts/25-xxx-specifications.txt
+++ b/drafts/25-xxx-specifications.txt
@@ -221,6 +221,11 @@ syntax below, we denote these as just "token-list" or
 "replacement-list".
 
 
+di00. The directives listed in di01-di08 are only recognized as such
+      if the token immediately following the '#' introducing a
+      directive line exactly matches one of the standard directive
+      names ('define', 'if', 'pragma', etc.).
+
 di01. The '#define' object-like macro directive
 
 di02. The '#define' function-like macro directive
@@ -230,13 +235,15 @@ di03. The '#undef' directive
 di04. The '#include' directive
 
 di05. The '#if', '#ifdef', '#ifndef', '#elif', '#elifdef',
-      '#elifndef', '#else', '#endif' directives
+      '#elifndef', '#else', '#endif' conditional directives
 
 di06. The '#error' and '#warning' directives
 
 di07. The '#line' directive
 
 di08. The '#pragma' directive
+
+
 
 di09. The null directive
 
@@ -315,7 +322,7 @@ df04. The identifier-list is a comma-separated list of ID tokens.
 df06. No identifier may appear more than once in the identifier-list.
 
 df08. The identifier names in the identifier-list define macro "parameters" that affect
-      macro expansion of the replacement list. (See the section "Macro recognition and 
+      macro expansion of the replacement list. (See the section "Macro recognition and
       expansion" for the semantics of function-like macro expansion.)
 
 df10. The replacement-list may be the empty sequence of tokens.
@@ -421,25 +428,28 @@ in28. Unlike INCLUDE lines (see the section on "INCLUDE lines"),
 
 Example syntax (extra spacing for illustration purposes only):
     General form:
-        <if-head>                        #endif EOL
-        <if-head>  <if-elif>             #endif EOL
-        <if-head>  <if-elif>  <if-else>  #endif EOL
+        <if-head>                             #endif EOL
+        <if-head>  <if-elif-list>             #endif EOL
+        <if-head>  <if-elif-list>  <if-else>  #endif EOL
 
     Where:
         <if-head> is one of:
-            #if token-list EOL  <lines>
-            #ifdef ID EOL       <lines>
-            #ifndef ID EOL      <lines>
+            #if token-list EOL  <group>
+            #ifdef ID EOL       <group>
+            #ifndef ID EOL      <group>
 
-        <if-elif> is zero or more of:
-            #elif     token-list EOL  <lines>
-            #elifdef  ID EOL          <lines>
-            #elifndef ID EOL          <lines>
+        <if-elif-list> is zero or more of:
+            <if-elif> <group>
 
-        <if-else> is zero or one of:
-            #else EOL  <lines>
+        <if-elif> is one of:
+            #elif     token-list EOL  <group>
+            #elifdef  ID EOL          <group>
+            #elifndef ID EOL          <group>
 
-        <lines> are zero or more of:
+        <if-else> is one of:
+            #else EOL  <group>
+
+        <group> is zero or more of:
             directive lines
             Fortran comment lines
             Fortran source lines
@@ -450,10 +460,6 @@ Example syntax (extra spacing for illustration purposes only):
 
 if05. A #if, #ifdef, or #ifndef directive signals the start of a list
       of conditional directives.
-
-if10: Whitespace must immediately follow the directives tokens
-      'ifdef', 'ifndef', 'elifdef', and 'elifndef' to separate them
-      from the ID tokens.
 
 if15. The list of #elif, #elifdef, and #elifndef directives, and the
       #else directive (if present) are part of the same list of
@@ -468,12 +474,6 @@ if25. Within a conditional directive list, a #if, #ifdef, or #endif
 
 if30. The conditional directive lists must properly nest.
 
-if35. As shown in the illustrative syntax, there should be no
-      unmatched #endif directives.
-
-if40. As shown in the illustrative syntax, there should be no more
-      than one #else directive in a list of conditional directives at
-      any nesting level.
 
 
 3.5.2 Evaluation semantics specifications
@@ -485,68 +485,80 @@ ix05. The #ifdef and #ifndef directives are evaluated as if they had been
       (For brevity, the descriptions of #ifdef and #ifndef directives
       below are omitted, and assume this transformation.)
 
-ix10. The #elifdef and #elifndef macros are evaluated as if they had
+ix10. The #elifdef and #elifndef directives are evaluated as if they had
       been written "#elif defined(ID)" and "#elif !defined(ID)"
       respectively.
 
-ix15. The token-lists in #if and #elif are processed as described in
-      the section "Macro recognition and expansion".
+ix12. In the descriptions below, <group> constructs may be "skipped".
+      When skipped,
+        - Conditional directives within the <group> are recognized only
+          to maintain proper nesting of conditional directives.
+        - No nested directives in the <group> are processed.
+        - No Fortran comment lines or source lines in the <group>
+          are examined for macro expansion.
+        - No skipped lines of any kind in the <group> are made available
+          subsequent processing by the processor.
 
-ix20. After expansion, the resulting token list in #if and #elif
-      directives must represent a valid integer expression as
+ix14. In the descriptions below, <group> constructs that are not
+      skipped participate in further preprocessing and processing.
+      When participating
+
+        - Macros are expanded in Fortran comment lines and source
+          lines.
+        - Nested directives in the <group> are processed.
+        - The resulting Fortran comment lines and source lines
+          are made available for subsequent processing by the
+          processor.
+
+ix15. Before evaluating the token-lists in the <if-head> and <if-elif>
+      constructs, macros in the token-lists are processed as described
+      in the section "Macro recognition and expansion".
+
+ix20. After expansion, the resulting token list in <if-head> and <if-elif>
+      constructs must be able to be parsed as a valid integer expression as
       described in the section "Expressions allowed in #if and #elif
-      directives". This expression is called the "controlling
+      directives" static semantics. This expression is called the "controlling
       expression" for the directive.
 
-ix25. Controlling expressions in #if and #elif directives are parsed
-      and evaluated according to the semantic rules described in
-      section "Expressions allowed in #if and #elif directives".
+ix25. The values of controlling expressions in <if-head> and <if-elif>
+      constructs are evaluated according to the evaluation semantics
+      described in the section "Expressions allowed in #if and #elif
+      directives".
 
-ix30. If the controlling expression in a #if evaluates to a nonzero
-      value, the <lines> immediately following the #if participate in
-      preprocessing. They are subject to preprocessing expansion,
-      substitution, and evaluation of processing directives in the
-      <lines>.
+ix30. If the controlling expression in an <if-head> evaluates to a
+      nonzero value, then the <group> contained within that <if-head>
+      construct participates in further preprocessing, as describe
+      above. Subsequent <if-elif> and <if-else> constructs at the same
+      level of nesting are skipped.
 
-ix40. Further preprocessing when #if controlling expression evaluates
-      to a nonzero value proceeds. Subsequent #elif and #else
-      directives at the same level of nesting are skipped, and do not
-      participate in preprocessing except to be examined for proper
-      nesting of conditional directives.
+ix45. If the controlling expression in an <if-head> construct
+      evaluates to a zero value, then the <group> contained within
+      that <if-head> construct is skipped. Preprocessing continues
+      with any <if-elif> constructs at the same level of nesting, as
+      described below.
 
-ix45. If the controlling expression in a #if evaluates to a zero
-      value, the lines immediately following the #if directive are
-      skipped, and examined only to determine nesting of conditionals.
-      Within these lines, no token expansion occurs, and no Fortran
-      comment lines nor source lines are made available for subsequent
-      processing by the processor. Preprocessing continues with any
-      #elif directives at the same level of nesting, as described
-      below.
+ix50. When the controlling expression in an <if-head> construct
+      evaluates to zero, the controlling expressions in each <if-elif>
+      construct at the same nesting level are evaluated in turn. Those
+      <group>s whose controlling expression evaluates to zero are
+      skipped.
 
-ix50. When the #if controlling expression evaluates to zero, the
-      controlling expressions in each of the #elif directives at the
-      same nesting level are evaluated in turn. Those whose expression
-      evaluate to false are skipped in the same manner as when a #if
-      clause evaluates to false.
+ix55. When the controlling expression in an <if-elif> construct
+      evaluates to a nonzero value, the <group> contained within that
+      <if-elif> construct continues to participate in preprocessing.
+      Subsequent <if-elif> constructs and any remaining <if-else>
+      constructs at the same nesting level are skipped.
 
-ix55. When a #elif controlling expression evaluates to a nonzero
-      value, the <lines> immediately following the #elif participate
-      in preprocessing just as they do when the controlling expression
-      in a #if evaluates to a nonzero value. Subsequent #elif and
-      #else directives at the same nesting level are skipped, as
-      described for #if.
+ix60. When all controlling expressions in the <if-head> construct and
+      <if-elif> constructs evaluate to a zero value and an <if-else>
+      construct is present at the same nesting level, the <group>
+      contained in the <if-else> construct continues to participate in
+      preprocessing.
 
-ix60. When all controlling expression in #if or #elif directives
-      evaluates to a zero value and a #else directive is present at
-      the same nesting level, the <lines> between the #else directive
-      and the matching #endif directive are subject to preprocessing,
-      expansion and substitution as they would be in #if true
-      processing.
-
-ix65. When all controlling expression in #if or #elif directives
-      evaluates to a zero value and no #else directive is present at
-      the same nesting level, there are no <lines> in the list of
-      conditional directives subject to preprocessing.
+ix65. When all controlling expressions in the <if-head> construct and
+      all <if-elif> constructs evaluate to a zero value and no
+      <if-else> construct is present at the same nesting level, then
+      all <group>s in these constructs are skipped.
 
 
 3.6 The '#error' and '#warning' directives

--- a/drafts/25-xxx-specifications.txt
+++ b/drafts/25-xxx-specifications.txt
@@ -448,98 +448,105 @@ Example syntax (extra spacing for illustration purposes only):
 3.5.1 Static semantics specifications
 -------------------------------------
 
-if05. A #if, ##ifdef, or #ifndef directive signals the start
-      of a list of conditional directives.
+if05. A #if, ##ifdef, or #ifndef directive signals the start of a list
+      of conditional directives.
 
 if10: Whitespace must immediately follow the directives tokens
-      'ifdef', 'ifndef', 'elifdef', and 'elifndef' to separate
-      them from the ID tokens.
+      'ifdef', 'ifndef', 'elifdef', and 'elifndef' to separate them
+      from the ID tokens.
 
-if15. The list of #elif, #elifdef, and #elifndef directives, and
-      the #else directive (if present) are part of the same list
-      of directives introduced by the #if directive.
+if15. The list of #elif, #elifdef, and #elifndef directives, and the
+      #else directive (if present) are part of the same list of
+      directives introduced by the #if directive.
 
 if20. The chain of conditional directives ends with the #endif
       directive.
 
-if25. Within a conditional directive list, a #if, #ifdef, or
-      #endif directive introduces a new list of conditional
-      directives, at a new nesting level, within the enclosing
-      conditional directive list.
+if25. Within a conditional directive list, a #if, #ifdef, or #endif
+      directive introduces a new list of conditional directives, at a new
+      nesting level, within the enclosing conditional directive list.
 
 if30. The conditional directive lists must properly nest.
 
-if35. As shown in the illustrative syntax, there should be
-      no unmatched #endif directives.
+if35. As shown in the illustrative syntax, there should be no
+      unmatched #endif directives.
 
-if40. As shown in the illustrative syntax, there should be
-      no more than one #else directive in a list of conditional
-      directives at any nesting level.
+if40. As shown in the illustrative syntax, there should be no more
+      than one #else directive in a list of conditional directives at
+      any nesting level.
 
 
 3.5.2 Evaluation semantics specifications
 -----------------------------------------
 
 
-ix05. The #ifdef and #ifndef macros are evaluated as if
-      they had been written "#if defined(ID)" and
-      "#if !defined(ID)" respectively.
+ix05. The #ifdef and #ifndef macros are evaluated as if they had been
+      written "#if defined(ID)" and "#if !defined(ID)" respectively.
+      (For brevity, the descriptions of #ifdef and #ifndef directives
+      below are omitted, and assume this transformation.)
 
-ix10. The #elifdef and #elifndef macros are evaluated as if
-      they had been written "#elif defined(ID)" and "#elif !defined(ID)"
+ix10. The #elifdef and #elifndef macros are evaluated as if they had
+      been written "#elif defined(ID)" and "#elif !defined(ID)"
       respectively.
 
-ix15. The token-lists in #if and #elif are processed as described
-      in the section "Macro recognition and expansion".
+ix15. The token-lists in #if and #elif are processed as described in
+      the section "Macro recognition and expansion".
 
 ix20. After expansion, the resulting token list in #if and #elif
       directives must represent a valid integer expression as
-      described in the section "Expressions allowed in #if and
-      #elif directives".
+      described in the section "Expressions allowed in #if and #elif
+      directives". This expression is called the "controlling
+      expression" for the directive.
 
-ix25. The resulting token list is parsed and evaluated according
-      to the semantic rules described in section "Expressions allowed
-      in #if and #elif directives".
+ix25. Controlling expressions in #if and #elif directives are parsed
+      and evaluated according to the semantic rules described in
+      section "Expressions allowed in #if and #elif directives".
 
-ix30. If the expression in a #if evaluates to a C true value, the
-      <lines> immediately following the #if participate in preprocessing.
-      They are subject to preprocessing expansion,  substitution, and
-      evaluation of processing directives in the <lines>.
+ix30. If the controlling expression in a #if evaluates to a nonzero
+      value, the <lines> immediately following the #if participate in
+      preprocessing. They are subject to preprocessing expansion,
+      substitution, and evaluation of processing directives in the
+      <lines>.
 
-ix40. Further preprocessing when #if evaluates to C true proceeds.
-      Subsequent #elif and #else directives at the same level of
-      nesting are skipped, and do not participate in preprocessing
-      except to be examined for proper nesting of conditional directives.
+ix40. Further preprocessing when #if controlling expression evaluates
+      to a nonzero value proceeds. Subsequent #elif and #else
+      directives at the same level of nesting are skipped, and do not
+      participate in preprocessing except to be examined for proper
+      nesting of conditional directives.
 
-ix45. If the expression in a #if evaluates to a C false value (zero),
-      the lines immediately following the #if directive are skipped, and
-      examined only to determine nesting of conditionals. No token
-      expansion occurs. No Fortran comment lines or source lines are
-      made available to the processor. Processing continues with
-      processing any #elif directives at the same level of nesting, as
-      described below.
+ix45. If the controlling expression in a #if evaluates to a zero
+      value, the lines immediately following the #if directive are
+      skipped, and examined only to determine nesting of conditionals.
+      Within these lines, no token expansion occurs, and no Fortran
+      comment lines nor source lines are made available for subsequent
+      processing by the processor. Preprocessing continues with any
+      #elif directives at the same level of nesting, as described
+      below.
 
-ix50. When the #if expression evaluates to C false, the #elif directives
-      at the same nesting level are evaluated in the order they appear
-      in the source. Those whose expression evaluate to false are
-      skipped in the same manner as when a #if clause evaluates to false.
+ix50. When the #if controlling expression evaluates to zero, the
+      controlling expressions in each of the #elif directives at the
+      same nesting level are evaluated in turn. Those whose expression
+      evaluate to false are skipped in the same manner as when a #if
+      clause evaluates to false.
 
-ix55. When a #elif expression evaluates to C true, the <lines>
-      immediately following the #elif participate in preprocessing
-      just as they do when the expression in a #if evaluates to C true.
-      Subsequent #elif and #else directives at the same nesting
-      level are skipped, as described for #if.
+ix55. When a #elif controlling expression evaluates to a nonzero
+      value, the <lines> immediately following the #elif participate
+      in preprocessing just as they do when the controlling expression
+      in a #if evaluates to a nonzero value. Subsequent #elif and
+      #else directives at the same nesting level are skipped, as
+      described for #if.
 
-ix60. When no #if expression or #elif expression evaluates to C true
-      and a #else directive is present at the same nesting level,
-      the <lines> between the #else directive and the matching #endif
-      directive are subject to preprocessing, expansion and substitution
-      as they would be in #if true processing.
+ix60. When all controlling expression in #if or #elif directives
+      evaluates to a zero value and a #else directive is present at
+      the same nesting level, the <lines> between the #else directive
+      and the matching #endif directive are subject to preprocessing,
+      expansion and substitution as they would be in #if true
+      processing.
 
-ix65. When no #if expression or #elif expression evaluates to C true
-      and no #else directive is present at the same nesting level,
-      there are no <lines> in the list of conditional directives
-      subject to preprocessing.
+ix65. When all controlling expression in #if or #elif directives
+      evaluates to a zero value and no #else directive is present at
+      the same nesting level, there are no <lines> in the list of
+      conditional directives subject to preprocessing.
 
 
 3.6 The '#error' and '#warning' directives

--- a/drafts/25-xxx-specifications.txt
+++ b/drafts/25-xxx-specifications.txt
@@ -243,8 +243,6 @@ di07. The '#line' directive
 
 di08. The '#pragma' directive
 
-
-
 di09. The null directive
 
 di10. The processor-dependent directive

--- a/drafts/25-xxx-specifications.txt
+++ b/drafts/25-xxx-specifications.txt
@@ -421,9 +421,9 @@ in28. Unlike INCLUDE lines (see the section on "INCLUDE lines"),
 
 Example syntax (extra spacing for illustration purposes only):
     General form:
-        <if-head>  <lines>                        #endif EOL
-        <if-head>  <lines>  <if-elif>             #endif EOL
-        <if-head>  <lines>  <if-elif>  <if-else>  #endif EOL
+        <if-head>                        #endif EOL
+        <if-head>  <if-elif>             #endif EOL
+        <if-head>  <if-elif>  <if-else>  #endif EOL
 
     Where:
         <if-head> is one of:

--- a/drafts/25-xxx-specifications.txt
+++ b/drafts/25-xxx-specifications.txt
@@ -426,7 +426,6 @@ in28. Unlike INCLUDE lines (see the section on "INCLUDE lines"),
 
 Example syntax (extra spacing for illustration purposes only):
     General form:
-        <if-head>                             #endif EOL
         <if-head>  <if-elif-list>             #endif EOL
         <if-head>  <if-elif-list>  <if-else>  #endif EOL
 
@@ -437,7 +436,7 @@ Example syntax (extra spacing for illustration purposes only):
             #ifndef ID EOL      <group>
 
         <if-elif-list> is zero or more of:
-            <if-elif> <group>
+            <if-elif>
 
         <if-elif> is one of:
             #elif     token-list EOL  <group>
@@ -466,7 +465,7 @@ if15. The list of #elif, #elifdef, and #elifndef directives, and the
 if20. The chain of conditional directives ends with the #endif
       directive.
 
-if25. Within a conditional directive list, a #if, #ifdef, or #endif
+if25. Within a conditional directive list, a #if, #ifdef, or #ifndef
       directive introduces a new list of conditional directives, at a new
       nesting level, within the enclosing conditional directive list.
 
@@ -485,21 +484,22 @@ ix05. The #ifdef and #ifndef directives are evaluated as if they had been
 
 ix10. The #elifdef and #elifndef directives are evaluated as if they had
       been written "#elif defined(ID)" and "#elif !defined(ID)"
-      respectively.
+      respectively. (For brevity, the descriptions below 
+      assume this transformation has been made).
 
 ix12. In the descriptions below, <group> constructs may be "skipped".
-      When skipped,
+      When skipped:
         - Conditional directives within the <group> are recognized only
           to maintain proper nesting of conditional directives.
         - No nested directives in the <group> are processed.
         - No macro expansion takes place in directive lines, Fortran
           comment lines or source lines in the <group>.
         - No skipped lines of any kind in the <group> are made available
-          subsequent processing by the processor.
+          to subsequent processing by the processor.
 
 ix14. In the descriptions below, <group> constructs that are not
       skipped participate in further preprocessing and processing.
-      When participating
+      When participating:
 
         - Macros are expanded in Fortran comment lines and source
           lines.
@@ -508,12 +508,12 @@ ix14. In the descriptions below, <group> constructs that are not
           are made available for subsequent processing by the
           processor.
 
-ix15. Before evaluating the token-lists in the <if-head> and <if-elif>
-      constructs, macros in the token-lists are processed as described
-      in the section "Macro recognition and expansion".
+ix15. Before evaluating the token-lists in any <if-head> and <if-elif>
+      constructs that are not skipped, macros in the token-lists are 
+      processed as described in the section "Macro recognition and expansion".
 
 ix20. After expansion, the resulting token list in <if-head> and <if-elif>
-      constructs must be able to be parsed as a valid integer expression as
+      constructs that are not skipped must be able to be parsed as a valid integer expression as
       described in the section "Expressions allowed in #if and #elif
       directives" static semantics. This expression is called the "controlling
       expression" for the directive.
@@ -525,7 +525,7 @@ ix25. The values of controlling expressions in <if-head> and <if-elif>
 
 ix30. If the controlling expression in an <if-head> evaluates to a
       nonzero value, then the <group> contained within that <if-head>
-      construct participates in further preprocessing, as describe
+      construct participates in further preprocessing, as described
       above. Subsequent <if-elif> and <if-else> constructs at the same
       level of nesting are skipped.
 
@@ -537,7 +537,8 @@ ix45. If the controlling expression in an <if-head> construct
 
 ix50. When the controlling expression in an <if-head> construct
       evaluates to zero, the controlling expressions in each <if-elif>
-      construct at the same nesting level are evaluated in turn. Those
+      construct at the same nesting level are evaluated in turn, until
+      one evaluates to a non-zero value. Those
       <group>s whose controlling expression evaluates to zero are
       skipped.
 


### PR DESCRIPTION
Initial draft of Section 3.5. Added illustrative syntax, static semantics and evaluation semantics, up to but not including controlling expression evaluation. (That will be an another section.)

I tried to use the terminology from the C 2023 standard, but reviewers will surely find lapses and potential improvements.