### PR TITLE
Reserve `#pragma STDF`

### DIFF
--- a/drafts/25-xxx-specifications.txt
+++ b/drafts/25-xxx-specifications.txt
@@ -632,7 +632,8 @@ pr02. The token-list may not be empty.
 3.8.2 Evaluation semantics specifications
 -----------------------------------------
 
-pr20. The token-list is expanded.
+pr20. The token-list is processed as in Fortran source fragments (see the
+      section on "Macro recognition and expansion" below).
 
 pr22. The #pragma directive causes the processor to behave
       in a processor-defined manner.

--- a/drafts/25-xxx-specifications.txt
+++ b/drafts/25-xxx-specifications.txt
@@ -929,6 +929,9 @@ dfc50. When determining argument boundaries in the invocation of a
        sets of `[  ]` or `(/  /)` brackets, in addition to matching
        sets of `(  )` parentheses.
 
+dfc60. The token-list in the FPP `#pragma` directive is always
+       subject to macro replacement, and may not be empty.
+
 Differences in the conditional expression grammar for `#if` and
 `#elif` directives include:
 

--- a/drafts/25-xxx-specifications.txt
+++ b/drafts/25-xxx-specifications.txt
@@ -628,6 +628,9 @@ Example syntax:
 
 pr02. The token-list may not be empty.
 
+pr10. The token-list shall not begin with the identifier `STDF`, either
+      before or after macro expansion.
+
 
 3.8.2 Evaluation semantics specifications
 -----------------------------------------

--- a/drafts/25-xxx-specifications.txt
+++ b/drafts/25-xxx-specifications.txt
@@ -635,8 +635,9 @@ pr10. The token-list shall not begin with the identifier `STDF`, either
 3.8.2 Evaluation semantics specifications
 -----------------------------------------
 
-pr20. The token-list is processed as in Fortran source fragments (see the
-      section on "Macro recognition and expansion" below).
+pr20. The semantics of the token-list are processor-dependent. 
+      In particular, it is processor-dependent whether macro 
+      expansion is performed on the token-list. 
 
 pr22. The #pragma directive causes the processor to behave
       in a processor-defined manner.
@@ -929,8 +930,7 @@ dfc50. When determining argument boundaries in the invocation of a
        sets of `[  ]` or `(/  /)` brackets, in addition to matching
        sets of `(  )` parentheses.
 
-dfc60. The token-list in the FPP `#pragma` directive is always
-       subject to macro replacement, and may not be empty.
+dfc60. The token-list in the FPP `#pragma` directive may not be empty.
 
 Differences in the conditional expression grammar for `#if` and
 `#elif` directives include:


### PR DESCRIPTION
This is analogous to CPP 6.10.8, which reserves `#pragma STDC` for use in standardized pragmas.