### PR TITLE
4.1 Macro recognition and expansion: Add placeholder text

### DIFF
--- a/drafts/25-xxx-specifications.txt
+++ b/drafts/25-xxx-specifications.txt
@@ -690,16 +690,38 @@ nd20. The result of evaluating a processor-dependent directive is processor-depe
 4 Macro recognition and expansion
 ---------------------------------
 
+NOTE: This section is currently incomplete.  A self-contained
+specification for macro recognition and expansion will appear in a
+forthcoming paper.
 
+4.1 Comparison to Macro recognition and expansion in CPP
+--------------------------------------------------------
 
+We intend for macro recognition and expansion to operate almost
+exactly as specified in C 2023 section 6.10.5, however it will differ
+in minor ways to accomodate Fortran syntax. The following exceptions
+have consensus amongst the authors:
 
-4.9 The '#' and '##' operators
-------------------------------
+me10. When determining argument boundaries in the invocation of a
+      function-like macro, FPP ignores commas surrounded by matching
+      sets of `[  ]` or `(/  /)` brackets, in addition to matching
+      sets of `(  )` parentheses (as specified in C 2023 section
+      6.10.5-11).
+
+Additional details are still under discussion and will be outlined in
+a future paper.
+
 4.2 The identifiers __VA_ARGS__ and __VA_OPT__
 ----------------------------------------------
 
+As specified in C 2023 section 6.10.5.1, see also section 4.1
+above.
 
+4.9 The '#' and '##' operators
+------------------------------
 
+As specified in C 2023 section 6.10.5.{2,3}, see also section 4.1
+above.
 
 
 5 Expressions allowed in #if and #elif directives
@@ -925,11 +947,6 @@ dfc30. FPP omits (and forbids) many predefined macros whose names begin
 dfc40. FPP expands macro invocations inside Fortran comments on
        source lines and in Fortran comment lines.
 
-dfc50. When determining argument boundaries in the invocation of a
-       function-like macro, FPP ignores commas surrounded by matching
-       sets of `[  ]` or `(/  /)` brackets, in addition to matching
-       sets of `(  )` parentheses.
-
 dfc60. The token-list in the FPP `#pragma` directive may not be empty.
 
 Differences in the conditional expression grammar for `#if` and
@@ -948,5 +965,6 @@ dfc88. FPP omits the `__has_c_attribute` expression added in C 2023.
 
 dfc90. FPP omits the `__has_embed` expression added in C 2023.
 
-[dob: This section may need to be amended as we settle on unresolved
-     topics such as _Pragma]
+Differences in macro recognition and expansion are currently
+documented explicitly in section 4.1.
+


### PR DESCRIPTION
As discussed in our 2025-05-28 and 2025-06-04 meetings, we want a placeholder in section 4 to convey our general intent and plan. This PR is a stripped-down version of PR #72 which includes just the verbiage that had consensus in the 2025-06-04 meeting.

This placeholder acknowledges the incomplete status, expresses our technical intent and references the relevant sections of C 2023 (which are long and subtle, but I believe the technical content really is almost exactly what we need to specify in final edits).

The one divergence from CPP noted is the only one from PR #72 that currently appears to have consensus.