### PR TITLE
Text cleanup

### DIFF
--- a/drafts/25-xxx-specifications.txt
+++ b/drafts/25-xxx-specifications.txt
@@ -1,4 +1,4 @@
-To: J3                                                         J3/25-xxx
+To: J3                                                      J3/25-xxx
 From: Gary Klimowicz & Dan Bonachea & Patrick Fasano
 Subject: Formal specifications for the Fortran preprocessor (FPP)
 Date: 2025-March-09
@@ -22,11 +22,12 @@ This is the formal specifications document, revised according to the
 discussion arising from 25-114r2.
 
 Terminology: For the purpose of this specification, the "preprocessor"
-encompasses any stages of preprocessing of the input text. For didactic
-purposes, that might include additional phases of "preprocessing" that
-help define the expected priorities of preprocessing behaviors. (In past
-discussions, these have included line continuation processing, comment
-handling, and tokenization for the preprocessor.)
+encompasses any stages of preprocessing of the input text. For
+didactic purposes, that might include additional phases of
+"preprocessing" that help define the expected priorities of
+preprocessing behaviors. (In past discussions, these have included
+line continuation processing, comment handling, and tokenization for
+the preprocessor.)
 
 
 
@@ -37,33 +38,35 @@ handling, and tokenization for the preprocessor.)
 2.1 Lines
 ---------
 
-li00. The Fortran preprocessor recognizes three distinct types of lines:
-      preprocessing directives (and continuation lines thereof),
-      Fortran comment lines, and Fortran source fragments.
+li00. The Fortran preprocessor recognizes three distinct types of
+      lines: preprocessing directives (and continuation lines
+      thereof), Fortran comment lines, and Fortran source fragments.
 
-li11. A line that has a '#'
-      character as the first non-blank character of the line is a
-      directive line (as required by C 2023 section 6.10.1 paragraph 2),
-      except when otherwise specified by the next two rules.
+li11. A line that has a '#' character as the first non-blank character
+      of the line is a directive line (as required by C 2023 section
+      6.10.1 paragraph 2), except when otherwise specified by the next
+      two rules.
 
 li13. In fixed-form input files, a '#' in column 6 of a non-comment
       line does not introduce a directive line.
 
 li15. A preprocessor directive can be continued with a backslash '\'
-      immediately followed by a new-line. The backslash and new-line are
-      deleted, the content of the subsequent line are textually appended
-      to the current directive, and the subsequent line is deleted.
-      This process repeats until the current directive does not end
-      with a backslash '\' immediately followed by a new-line.
+      immediately followed by a new-line. The backslash and new-line
+      are deleted, the content of the subsequent line are textually
+      appended to the current directive, and the subsequent line is
+      deleted. This process repeats until the current directive does
+      not end with a backslash '\' immediately followed by a new-line.
 
-li17. Preprocessor directive continuation processing described by the prior rule is
-      effectively performed before any other processing of the text in affected lines.
+li17. Preprocessor directive continuation processing described by the
+      prior rule is effectively performed before any other processing
+      of the text in affected lines.
 
 li19. The maximum length of a preprocessor directive (including
       continuation text) is one million characters.
 
-li21. A source file that ends with a directive line shall neither end with a '\',
-      nor a '\' followed immediately by a new-line (analogously to C 2023 section 5.1.1.2 bullet 2).
+li21. A source file that ends with a directive line shall neither end
+      with a '\', nor a '\' followed immediately by a new-line
+      (analogously to C 2023 section 5.1.1.2 bullet 2).
 
 li31. Fortran comment lines are defined as in 25-007 6.3.2.3 and
       6.3.3.2.
@@ -77,8 +80,8 @@ li43. Text on fixed-form Fortran source fragments is ignored beyond
 
 li45. Fortran source fragments may be continued with a continuation
       ('&' at the end of a free-form line as specified in Fortran 2023
-      6.3.2.4, or with a non-blank, non-zero character in column 6
-      of a fixed-form line as specified in Fortran 2023 6.3.3.3).
+      6.3.2.4, or with a non-blank, non-zero character in column 6 of
+      a fixed-form line as specified in Fortran 2023 6.3.3.3).
 
       Example 1 (free-form):
           call subroutine_foo(1, 2, &
@@ -115,8 +118,8 @@ cs05. Preprocessor-defined macro names are case-sensitive.
 2.3 Significance of whitespace
 ------------------------------
 
-ws01. The whitespace characters blank and horizontal tab character may appear
-      on directive lines.
+ws01. The whitespace characters blank and horizontal tab character may
+      appear on directive lines.
 
 ws02. Whitespace may appear before or after the '#' character that
       introduces a directive line.
@@ -154,9 +157,10 @@ co05. '/*' ... '*/' comments on directive lines shall extend past a
 co07. '/*' ... '*/' comments on directive lines are replaced by a
       single space, as specified in C 2023 section 5.1.1.2 bullet 3.
 
-co09. In a directive line, the '!' character is not interpreted as introducing
-      a Fortran-style comment, and neither the '!' character nor any subsequent
-      text are removed by the preprocessor.
+co09. In a directive line, the '!' character is not interpreted as
+      introducing a Fortran-style comment, and neither the '!'
+      character nor any subsequent text are removed by the
+      preprocessor.
 
 co11. Directive lines (by definition) cannot contain Fortran
       fixed-form 'C' or '*' style comments.
@@ -166,19 +170,24 @@ co11. Directive lines (by definition) cannot contain Fortran
 2.5 Token lexicon
 -----------------
 
-The preprocessor decomposes the source file into preprocessing tokens (see C 2023 section 5.1.1.2
-Translation phases).
-As such, there is a specific lexicon of tokens recognized by
-the preprocessor (including unrecognizable tokens).
-As in C 2023, these tokens are recognized after any line and
-comment handling specified in section 2.1 "Lines" and section 2.4 "Comments" above.
+The preprocessor decomposes the source file into preprocessing tokens
+(see C 2023 section 5.1.1.2 Translation phases).
+
+As such, there is a specific lexicon of tokens recognized by the
+preprocessor (including unrecognizable tokens).
+
+As in C 2023, these tokens are recognized after any line and comment
+handling specified in section 2.1 "Lines" and section 2.4 "Comments"
+above.
 
 We use illustrative syntax to describe the directive specifications,
-and the translation behavior of the preprocess on Fortran comment lines
-and Fortran source fragment lines.
+and the translation behavior of the preprocess on Fortran comment
+lines and Fortran source fragment lines.
 
 This illustrative syntax makes use of these "tokens".
-Further definition of the recognized tokens is deferred to the upcoming preprocessor syntax paper.
+
+Further definition of the recognized tokens is deferred to the
+upcoming preprocessor syntax paper.
 
 
 to01. In the definitions of object macros and function-like macros,
@@ -188,25 +197,28 @@ to01. In the definitions of object macros and function-like macros,
       source lines, those allowed in C integer expressions,
       and any additional tokens recognized by the processor.
 
-to03. Without naming all the tokens explicitly, they appear in the illustrative
-      syntax in subsequent sections.
+to03. Without naming all the tokens explicitly, they appear in the
+      illustrative syntax in subsequent sections.
 
 
 to09. The preprocessor is line-oriented. To define the end of
       a logical line (after continuation handling), the 'EOL' token
       is shown explicitly in the illustrative syntax.
 
-to11. The following tokens also appear in the illustrative syntax below.
+to11. The following tokens also appear in the illustrative syntax
+below.
 
-      |---------------------|-------------------------------------------|
-      | Token name          |  Characters                               |
-      |---------------------|-------------------------------------------|
-      | ID                  | Regex [A-Za-z][A-Za-z0-9_]*               |
-      | WHOLE_NUMBER        | Regex [0-9]+                              |
-      | CHARACTER_STRING    | RegEx "[^"\n]*" where '\n' represents new-line. |
-      | EOL                 | The new-line ending a directive line,     |
-      |                     | after continuation processing (see li15). |
-      |---------------------|-------------------------------------------|
+      |---------------------|---------------------------------------|
+      | Token name          |  Characters                           |
+      |---------------------|---------------------------------------|
+      | ID                  | Regex [A-Za-z][A-Za-z0-9_]*           |
+      | WHOLE_NUMBER        | Regex [0-9]+                          |
+      | CHARACTER_STRING    | RegEx "[^"\n]*" where '\n' represents |
+      |                     |    new-line.                          |
+      | EOL                 | The new-line ending a directive line, |
+      |                     | after continuation processing (see    |
+      |                     |    li15).                             |
+      |---------------------|---------------------------------------|
 
 
 
@@ -221,8 +233,8 @@ below.
 We use illustrative syntax in the detailed descriptions. Detailed
 syntax will appear in a paper to be named later.
 
-Most directives take a sequence of tokens (as defined in
-section 2.5 "Token lexicon" above). In the detailed descriptions and illustrative
+Most directives take a sequence of tokens (as defined in section 2.5
+"Token lexicon" above). In the detailed descriptions and illustrative
 syntax below, we denote these as just "token-list" or
 "replacement-list".
 
@@ -291,10 +303,10 @@ do22. There is one namespace for all macro identifiers.
 do24. The #define directive does not scan the replacement-list
       for macros to expand.
 
-do26. An identifier currently defined as an object-like macro shall not
-      be redefined by another #define preprocessing directive unless
-      the second definition is an object-like macro definition and
-      the two replacement lists are identical (as in C 2023).
+do26. An identifier currently defined as an object-like macro shall
+      not be redefined by another #define preprocessing directive
+      unless the second definition is an object-like macro definition
+      and the two replacement lists are identical (as in C 2023).
 
 do28. Two replacement lists are identical if and only if the
       preprocessing tokens in both have the same number, ordering,
@@ -327,19 +339,21 @@ df04. The identifier-list is a comma-separated list of ID tokens.
 
 df06. No identifier may appear more than once in the identifier-list.
 
-df08. The identifier names in the identifier-list define macro "parameters" that affect
-      macro expansion of the replacement list. (See section 4 "Macro recognition and
-      expansion" for the semantics of function-like macro expansion.)
+df08. The identifier names in the identifier-list define macro
+      "parameters" that affect macro expansion of the replacement
+      list. (See section 4 "Macro recognition and expansion" for the
+      semantics of function-like macro expansion.)
 
 df10. The replacement-list may be the empty sequence of tokens.
 
 df12. Whitespace before or after the replacement-list is not
       considered to be part of the replacement-list.
 
-df16. The '...' between the parentheses specifies that the function-like
-      macro may be invoked with a variable number of arguments. (See
-      section 4 "Macro recognition and expansion" for the semantics of function-like macros
-      with a variable number of arguments.)
+df16. The '...' between the parentheses specifies that the
+      function-like macro may be invoked with a variable number of
+      arguments. (See section 4 "Macro recognition and expansion" for
+      the semantics of function-like macros with a variable number of
+      arguments.)
 
 
 
@@ -350,14 +364,14 @@ df30. This #define directive defines a function-like macro named by ID
       with the specified macro parameters and with a replacement list
       comprised of the tokens specified in the replacement-list.
 
-df32. This #define directive does not scan the replacement-list
-      for macros to expand.
+df32. This #define directive does not scan the replacement-list for
+      macros to expand.
 
-df34. An identifier currently defined as a function-like macro shall not
-      be redefined by another #define preprocessing directive unless
-      the second definition is a function-like macro definition, with
-      the same number and spelling of the parameters, and the two
-      replacement lists are identical (as in C 2023).
+df34. An identifier currently defined as a function-like macro shall
+      not be redefined by another #define preprocessing directive
+      unless the second definition is a function-like macro
+      definition, with the same number and spelling of the parameters,
+      and the two replacement lists are identical (as in C 2023).
 
 
 
@@ -372,8 +386,8 @@ Example syntax:
 3.3.1 Static semantics specifications
 -------------------------------------
 
-ud02. ID shall not be one of the macros defined in section 7 "Predefined macros"
-       below.
+ud02. ID shall not be one of the macros defined in section 7
+       "Predefined macros" below.
 
 ud04. The specified identifier may or may not have been defined.
 
@@ -382,8 +396,8 @@ ud04. The specified identifier may or may not have been defined.
 3.3.2 Evaluation semantics specifications
 -----------------------------------------
 
-ud20. If no definition exists for the identifier ID, this directive has
-      no effect.
+ud20. If no definition exists for the identifier ID, this directive
+      has no effect.
 
 ud22. The definition for the object-like macro or function-like macro
       named by ID is removed.
@@ -414,14 +428,15 @@ in08. In the third form, the token-list does not match the previous
 
 in18. In the third form, the token-list is processed as in Fortran
       source fragments (see section 4 "Macro recognition and
-      expansion" below). The directive resulting after all replacements
-      shall match one of the previous two forms, and evaluation proceeds
-      as such.
+      expansion" below). The directive resulting after all
+      replacements shall match one of the previous two forms, and
+      evaluation proceeds as such.
 
 in20. The preprocessor searches in processor-defined places for the
       file denoted by the CHARACTER_STRING or the character-list.
 
-in22. It is an error if the processor cannot locate the specified file.
+in22. It is an error if the processor cannot locate the specified
+      file.
 
 in24. If the file is located, the processor replaces the #include
       directive line with the contents of that file.
@@ -429,9 +444,9 @@ in24. If the file is located, the processor replaces the #include
 in26. A #include directive may appear in an included file, up to a
       processor-defined nesting limit.
 
-in28. Unlike INCLUDE lines (see Fortran 2023 section 6.4, "Including source text"),
-      the #include directive is not prohibited from including the
-      same source file at a deeper level of nesting.
+in28. Unlike INCLUDE lines (see Fortran 2023 section 6.4, "Including
+      source text"), the #include directive is not prohibited from
+      including the same source file at a deeper level of nesting.
 
 
 
@@ -481,8 +496,9 @@ if20. The chain of conditional directives ends with the #endif
       directive.
 
 if25. Within a conditional directive chain, a #if, #ifdef, or #ifndef
-      directive introduces a new chain of conditional directives, at a new
-      nesting level, within the enclosing conditional directive chain.
+      directive introduces a new chain of conditional directives, at a
+      new nesting level, within the enclosing conditional directive
+      chain.
 
 if30. The conditional directive chains must properly nest.
 
@@ -492,25 +508,26 @@ if30. The conditional directive chains must properly nest.
 -----------------------------------------
 
 
-ix05. The #ifdef and #ifndef directives are evaluated as if they had been
-      written '#if defined(ID)' and '#if !defined(ID)' respectively.
-      (For brevity, the descriptions of #ifdef and #ifndef directives
-      below are omitted, and assume this transformation.)
+ix05. The #ifdef and #ifndef directives are evaluated as if they had
+      been written '#if defined(ID)' and '#if !defined(ID)'
+      respectively. (For brevity, the descriptions of #ifdef and
+      #ifndef directives below are omitted, and assume this
+      transformation.)
 
-ix10. The #elifdef and #elifndef directives are evaluated as if they had
-      been written '#elif defined(ID)' and '#elif !defined(ID)'
-      respectively. (For brevity, the descriptions below
-      assume this transformation has been made).
+ix10. The #elifdef and #elifndef directives are evaluated as if they
+      had been written '#elif defined(ID)' and '#elif !defined(ID)'
+      respectively. (For brevity, the descriptions below assume this
+      transformation has been made).
 
 ix12. In the descriptions below, <group> constructs may be "skipped".
       When skipped:
-        - Conditional directives within the <group> are recognized only
-          to maintain proper nesting of conditional directives.
+        - Conditional directives within the <group> are recognized
+          only to maintain proper nesting of conditional directives.
         - No nested directives in the <group> are processed.
         - No macro expansion takes place in directive lines, Fortran
           comment lines or source lines in the <group>.
-        - No skipped lines of any kind in the <group> are made available
-          to subsequent processing by the processor.
+        - No skipped lines of any kind in the <group> are made
+          available to subsequent processing by the processor.
 
 ix14. In the descriptions below, <group> constructs that are not
       skipped participate in further preprocessing and processing.
@@ -525,12 +542,14 @@ ix14. In the descriptions below, <group> constructs that are not
 
 ix15. Before evaluating the token-lists in any <if-head> and <if-elif>
       constructs that are not skipped, macros in the token-lists are
-      processed as described in section 4 "Macro recognition and expansion".
+      processed as described in section 4 "Macro recognition and
+      expansion".
 
-ix20. After expansion, the resulting token list in <if-head> and <if-elif>
-      constructs that are not skipped must be able to be parsed as a valid integer expression as
-      described in section 5 "Expressions allowed in #if and #elif
-      directives" static semantics. This expression is called the "controlling
+ix20. After expansion, the resulting token list in <if-head> and
+      <if-elif> constructs that are not skipped must be able to be
+      parsed as a valid integer expression as described in section 5
+      "Expressions allowed in #if and #elif directives" static
+      semantics. This expression is called the "controlling
       expression" for the directive.
 
 ix25. The values of controlling expressions in <if-head> and <if-elif>
@@ -647,8 +666,8 @@ Example syntax:
 
 pr02. The token-list may not be empty.
 
-pr10. The token-list shall not begin with the identifier 'STDF', either
-      before or after macro expansion.
+pr10. The token-list shall not begin with the identifier 'STDF',
+      either before or after macro expansion.
 
 
 3.8.2 Evaluation semantics specifications
@@ -658,11 +677,10 @@ pr20. The semantics of the token-list are processor-dependent.
       In particular, it is processor-dependent whether macro
       expansion is performed on the token-list.
 
-pr22. The #pragma directive causes the processor to behave
-      in a processor-defined manner.
+pr22. The #pragma directive causes the processor to behave in a
+      processor-defined manner.
 
-pr24. Any #pragma that is not recognized by the processor
-      is ignored.
+pr24. Any #pragma that is not recognized by the processor is ignored.
 
 
 
@@ -705,7 +723,8 @@ nd02. The token-list in a processor-dependent directive may not begin
 3.10.2 Evaluation semantics specifications
 -------------------------------------------
 
-nd20. The result of evaluating a processor-dependent directive is processor-dependent.
+nd20. The result of evaluating a processor-dependent directive is
+      processor-dependent.
 
 
 
@@ -756,101 +775,105 @@ above.
 =================================================
 
 
-ex05. When evaluating a #if or #elif directive, first every instance of the
-      'defined ID' or 'defined(ID)' operator is evaluated and replaced with
-      the resulting WHOLE_NUMBER. A 'defined' expression evaluates to 1 if
-      the identifier is currently defined as a macro name (that is, if it is
-      predefined or if it has been the subject of a '#define' preprocessing
-      directive without an intervening '#undef' directive with the same
-      subject identifier), 0 if it is not.
+ex05. When evaluating a #if or #elif directive, first every instance
+      of the 'defined ID' or 'defined(ID)' operator is evaluated and
+      replaced with the resulting WHOLE_NUMBER. A 'defined' expression
+      evaluates to 1 if the identifier is currently defined as a macro
+      name (that is, if it is predefined or if it has been the subject
+      of a '#define' preprocessing directive without an intervening
+      '#undef' directive with the same subject identifier), 0 if it is
+      not.
 
-ex10. When evaluating a #if or #elif directive and after 'define' processing
-      described in ex05, the token-list is then subjected to macro expansion
-      and replacement (see section 4 "Macro recognition and expansion").
-      This results in a token-list of the expression to be
-      evaluated.
+ex10. When evaluating a #if or #elif directive and after 'define'
+      processing described in ex05, the token-list is then subjected
+      to macro expansion and replacement (see section 4 "Macro
+      recognition and expansion"). This results in a token-list of the
+      expression to be evaluated.
 
-ex12. Since expression evaluation occurs *after* macro expansion, there will
-      be no object-like macro or function-like macro invocations left to expand.
-      All remaining IDs are replaced with the WHOLE_NUMBER 0.
+ex12. Since expression evaluation occurs *after* macro expansion,
+      there will be no object-like macro or function-like macro
+      invocations left to expand. All remaining IDs are replaced with
+      the WHOLE_NUMBER 0.
 
 ex15. The resulting list of tokens shall be a valid expression
       comprised of WHOLE_NUMBERs and operators as described
       below.
 
-ex17. Preprocessing computes the integer value of conditional expressions
-      using the greatest integer range available to the processor to
-      determine the truth or falsity of the controlling expression.
+ex17. Preprocessing computes the integer value of conditional
+      expressions using the greatest integer range available to the
+      processor to determine the truth or falsity of the controlling
+      expression.
 
-ex20. The processor shall reject a program if evaluation of
-      the expression generates a computational error (such
-      as divide by zero).
+ex20. The processor shall reject a program if evaluation of the
+      expression generates a computational error (such as divide by
+      zero).
 
-ex25. When the expression evaluates to zero, the controlling expression
-      will be considered "false". If the expression evaluates to
-      any non-zero value, the controlling expression will be considered
-      "true".
+ex25. When the expression evaluates to zero, the controlling
+      expression will be considered "false". If the expression
+      evaluates to any non-zero value, the controlling expression will
+      be considered "true".
 
 
 5.1 Operators allowed in controlling expressions
 ------------------------------------------------
 
-op01. To maintain compatibility with the use of C preprocessing directives
-      in many existing Fortran programs, the operators allowed in
-      controlling expressions in #if and #elif expressions are a subset of
-      those defined in C 2023 section 6.5 "Expressions" and section 6.6
-      "Constant expressions".
+op01. To maintain compatibility with the use of C preprocessing
+      directives in many existing Fortran programs, the operators
+      allowed in controlling expressions in #if and #elif expressions
+      are a subset of those defined in C 2023 section 6.5
+      "Expressions" and section 6.6 "Constant expressions".
 
-op03. A "precedence level" is assigned to each operator that determines
-      how the operators combine with sub-expressions containing other operators
-      at different precedence levels.
+op03. A "precedence level" is assigned to each operator that
+      determines how the operators combine with sub-expressions
+      containing other operators at different precedence levels.
 
-op05. An "associativity" is assigned to each operator that determines how
-      operators at the same precedence level are combined.
-          - "left" means the operator binds to the left,
-          - "right" means the operator binds to the right.
-          - "nonassoc" means that the operator is not associative.
+op05. An "associativity" is assigned to each operator that determines
+      how operators at the same precedence level are combined. -
+      "left" means the operator binds to the left, - "right" means the
+      operator binds to the right. - "nonassoc" means that the
+      operator is not associative.
 
-op07. The following table describes the semantics of the allowed operators
-      in conditional expressions. The table is grouped by precedence level,
-      from lowest precedence to highest.
+op07. The following table describes the semantics of the allowed
+      operators in conditional expressions. The table is grouped by
+      precedence level, from lowest precedence to highest.
 
-      We label subexpressions "e1", "e2", and "e3" to aid in describing the
-      evaluation semantics. Unless otherwise specified, all operators
-      evaluate with the same semantics as their Fortran counterparts.
+      We label subexpressions "e1", "e2", and "e3" to aid in
+      describing the evaluation semantics. Unless otherwise specified,
+      all operators evaluate with the same semantics as their Fortran
+      counterparts.
 
 
-| Prec |   Op    |    Syntax    |  Assoc'y |  Evaluation Semantics      |
+| Prec |   Op    |    Syntax    | Assoc'y  |  Evaluation Semantics      |
 |------+---------+--------------+----------+----------------------------|
 | low  |   ? :   | e1 ? e2 : e3 |  right   |      conditional-expr      |
 |------+---------+--------------+----------+----------------------------|
-|      |   ¦¦    |   e1 || e2   |   left   |    logical OR (see op12)   |
+|      |   ¦¦    |   e1 || e2   |  left    |   logical OR (see op12)    |
 |------+---------+--------------+----------+----------------------------|
-|      |   &&    |   e1 && e2   |   left   |   logical AND (see op13)   |
+|      |   &&    |   e1 && e2   |  left    |   logical AND (see op13)   |
 |------+---------+--------------+----------+----------------------------|
-|      |    ¦    |   e1 | e2    |   left   |    Fortran IOR(e1, e2)     |
+|      |    ¦    |   e1 | e2    |  left    |    Fortran IOR(e1, e2)     |
 |------+---------+--------------+----------+----------------------------|
-|      |    ^    |   e1 ^ e2    |   left   |    Fortran IAND(e1, e2)    |
+|      |    ^    |   e1 ^ e2    |  left    |    Fortran IAND(e1, e2)    |
 |------+---------+--------------+----------+----------------------------|
-|      |    &    |   e1 & e2    |   left   |    Fortran IEOR(e1, e2)    |
+|      |    &    |   e1 & e2    |  left    |    Fortran IEOR(e1, e2)    |
 |------+---------+--------------+----------+----------------------------|
-|      |   ==    |   e1 == e2   |   left   | 1 if e1 == e2, 0 otherwise |
-|      |   !=    |   e1 != e2   |   left   | 1 if e1 /= e2, 0 otherwise |
+|      |   ==    |   e1 == e2   |  left    | 1 if e1 == e2, 0 otherwise |
+|      |   !=    |   e1 != e2   |  left    | 1 if e1 /= e2, 0 otherwise |
 |------+---------+--------------+----------+----------------------------|
-|      |    >    |   e1 > e2    |   left   | 1 if e1 > e2, 0 otherwise  |
-|      |   >=    |   e1 >= e2   |   left   | 1 if e1 >= e2, 0 otherwise |
-|      |    <    |   e1 < e2    |   left   | 1 if e1 < e2, 0 otherwise  |
-|      |   <=    |   e1 <= e2   |   left   | 1 if e1 <= e2, 0 otherwise |
+|      |    >    |   e1 > e2    |  left    | 1 if e1 > e2, 0 otherwise  |
+|      |   >=    |   e1 >= e2   |  left    | 1 if e1 >= e2, 0 otherwise |
+|      |    <    |   e1 < e2    |  left    | 1 if e1 < e2, 0 otherwise  |
+|      |   <=    |   e1 <= e2   |  left    | 1 if e1 <= e2, 0 otherwise |
 |------+---------+--------------+----------+----------------------------|
-|      |   <<    |   e1 << e2   |   left   | Fortran ISHFT(e1, e2)      |
-|      |   >>    |   e1 >> e2   |   left   | Fortran ISHFT(e1, -e2)     |
+|      |   <<    |   e1 << e2   |  left    | Fortran ISHFT(e1, e2)      |
+|      |   >>    |   e1 >> e2   |  left    | Fortran ISHFT(e1, -e2)     |
 |------+---------+--------------+----------+----------------------------|
-|      |    +    |   e1 + e2    |   left   |             +              |
-|      |    -    |   e1 - e2    |   left   |             -              |
+|      |    +    |   e1 + e2    |  left    |             +              |
+|      |    -    |   e1 - e2    |  left    |             -              |
 |------+---------+--------------+----------+----------------------------|
-|      |    *    |   e1 * e2    |   left   |             *              |
-|      |    /    |   e1 / e2    |   left   |             /              |
-|      |    %    |   e1 % e2    |   left   |    Fortran MOD(e1, e2)     |
+|      |    *    |   e1 * e2    |  left    |             *              |
+|      |    /    |   e1 / e2    |  left    |             /              |
+|      |    %    |   e1 % e2    |  left    |    Fortran MOD(e1, e2)     |
 |------+---------+--------------+----------+----------------------------|
 |      | unary + |     + e1     |  right   |        unary +             |
 |      | unary - |     - e1     |  right   |        unary -             |
@@ -861,15 +884,15 @@ op07. The following table describes the semantics of the allowed operators
 |------+---------+--------------+----------+----------------------------|
 
 
-op12. The logical OR operator guarantees left-to-right evaluation; if the first
-      operand evaluates to non-zero, the second operand is not evaluated and the
-      resulting value is 1. Otherwise, the second operand is evaluated
-      and provides the resulting value.
+op12. The logical OR operator guarantees left-to-right evaluation; if
+      the first operand evaluates to non-zero, the second operand is
+      not evaluated and the resulting value is 1. Otherwise, the
+      second operand is evaluated and provides the resulting value.
 
-op13. The logical AND operator guarantees left-to-right evaluation; if the first
-      operand evaluates to 0, the second operand is not evaluated and the
-      resulting value is 0. Otherwise, the second operand is evaluated
-      and provides the resulting value.
+op13. The logical AND operator guarantees left-to-right evaluation; if
+      the first operand evaluates to 0, the second operand is not
+      evaluated and the resulting value is 0. Otherwise, the second
+      operand is evaluated and provides the resulting value.
 
 
 
@@ -877,12 +900,12 @@ op13. The logical AND operator guarantees left-to-right evaluation; if the first
 7 Predefined macros
 ===================
 
-pm00. Macro names beginning with a leading underscore followed by an uppercase
-      letter or a second underscore are reserved to the processor. Reserved
-      names shall not be the subject of a #define or #undef preprocessing
-      directive within a program unit.
-      [Note: Any macro name matching the regular expression '/^_[A-Z_][A-Za-z0-9_]*$/'
-      is considered reserved.]
+pm00. Macro names beginning with a leading underscore followed by an
+      uppercase letter or a second underscore are reserved to the
+      processor. Reserved names shall not be the subject of a #define
+      or #undef preprocessing directive within a program unit. [Note:
+      Any macro name matching the regular expression
+      '/^_[A-Z_][A-Za-z0-9_]*$/' is considered reserved.]
 
 pm01. Any macro name predefined by the processor shall begin with a
       leading underscore followed by an uppercase letter or a second
@@ -891,18 +914,19 @@ pm01. Any macro name predefined by the processor shall begin with a
 pm02. The processor shall not predefine the macro '__cplusplus',
       nor any macro whose name starts with '__STDC'.
 
-pm03. Unless listed in the following subclauses, the processor shall not
-      predefine any macro whose name starts with '__STDF' or '__stdf'.
+pm03. Unless listed in the following subclauses, the processor shall
+      not predefine any macro whose name starts with '__STDF' or
+      '__stdf'.
 
-pm10. The values of the predefined macros listed in the following subclauses
-      (except for '__FILE__' and '__LINE__') remain constant throughout the
-      program unit.
+pm10. The values of the predefined macros listed in the following
+      subclauses (except for '__FILE__' and '__LINE__') remain
+      constant throughout the program unit.
 
-pm12. The identifier 'defined' shall not be the subject of a #define or a #undef
-      preprocessing directive.
+pm12. The identifier 'defined' shall not be the subject of a #define
+      or a #undef preprocessing directive.
 
-pm15. The presumed source file name and line number can be changed by the #line
-      directive.
+pm15. The presumed source file name and line number can be changed by
+      the #line directive.
 
 The following macro names shall be defined by the processor:
 
@@ -918,37 +942,40 @@ pm20. '__LINE__' shall be predefined to a WHOLE_NUMBER representing
 7.2 __FILE__
 ------------
 
-pm30. '__FILE__' shall be predefined to a CHARACTER_STRING representing
-      the presumed name of the current source file
+pm30. '__FILE__' shall be predefined to a CHARACTER_STRING
+      representing the presumed name of the current source file
 
 
 7.3 __DATE__
 ------------
 
-pm40. '__DATE__' shall be predefined to a CHARACTER_STRING representing
-      the date of translation of the preprocessing program unit
+pm40. '__DATE__' shall be predefined to a CHARACTER_STRING
+      representing the date of translation of the preprocessing
+      program unit
 
-pm41. '__DATE__' shall be a character literal constant of the form "Mmm dd yyyy",
-      where the names of the months are the same as those specified in C 2023 for the
-      asctime function, and the first character of dd is a space character if the
-      value is less than 10.
+pm41. '__DATE__' shall be a character literal constant of the form
+      "Mmm dd yyyy", where the names of the months are the same as
+      those specified in C 2023 for the asctime function, and the
+      first character of dd is a space character if the value is less
+      than 10.
 
-pm42. If the date of translation is not available, a processor-dependent
-      valid date shall be supplied.
+pm42. If the date of translation is not available, a
+      processor-dependent valid date shall be supplied.
 
 
 7.4 __TIME__
 ------------
 
-pm50. '__TIME__' shall be predefined to a CHARACTER_STRING representing
-      the time of translation of the preprocessing program unit
+pm50. '__TIME__' shall be predefined to a CHARACTER_STRING
+      representing the time of translation of the preprocessing
+      program unit
 
-pm51. '__TIME__' shall be a character literal constant of the form "hh:mm:ss",
-      where hh is the hour of the day, mm is the minutes of the hour, and ss is the
-      seconds of the minute.
+pm51. '__TIME__' shall be a character literal constant of the form
+      "hh:mm:ss", where hh is the hour of the day, mm is the minutes
+      of the hour, and ss is the seconds of the minute.
 
-pm52. If the time of translation is not available, a processor-dependent
-      valid time shall be supplied.
+pm52. If the time of translation is not available, a
+      processor-dependent valid time shall be supplied.
 
 
 7.5 __STDF__
@@ -981,8 +1008,8 @@ dfc10. FPP does not recognize '//'-style comments on directive lines.
 
 dfc20. FPP omits the '#embed' directive added in C 2023.
 
-dfc30. FPP omits (and forbids) many predefined macros whose names begin
-       with '__STDC'.
+dfc30. FPP omits (and forbids) many predefined macros whose names
+       begin with '__STDC'.
 
 dfc40. FPP expands macro invocations inside Fortran comments on
        source lines and in Fortran comment lines.

--- a/drafts/25-xxx-specifications.txt
+++ b/drafts/25-xxx-specifications.txt
@@ -690,7 +690,7 @@ nd20. The result of evaluating a processor-dependent directive is processor-depe
 4 Macro recognition and expansion
 ---------------------------------
 
-NOTE: This section is currently incomplete.  A self-contained
+NOTE: This section is currently incomplete. A self-contained
 specification for macro recognition and expansion will appear in a
 forthcoming paper.
 

--- a/drafts/25-xxx-specifications.txt
+++ b/drafts/25-xxx-specifications.txt
@@ -11,6 +11,7 @@ References: 25-114r2 Fortran preprocessor requirements
                    (working draft N3096)
 
 
+
 1 Introduction
 ==============
 
@@ -28,8 +29,10 @@ discussions, these have included line continuation processing, comment
 handling, and tokenization for the preprocessor.)
 
 
+
 2 Lexical specifications
 ========================
+
 
 2.1 Lines
 ---------
@@ -136,6 +139,7 @@ ws11. In fixed-form input, macro names are not recognized as such when
       spaces are inserted into their invocations.
 
 
+
 2.4 Comments
 ------------
 
@@ -156,6 +160,7 @@ co09. In a directive line, the '!' character is not interpreted as introducing
 
 co11. Directive lines (by definition) cannot contain Fortran
       fixed-form 'C' or '*' style comments.
+
 
 
 2.5 Token lexicon
@@ -202,6 +207,7 @@ to11. The following tokens also appear in the illustrative syntax below.
       | EOL                 | The new-line ending a directive line,     |
       |                     | after continuation processing (see li15). |
       |---------------------|-------------------------------------------|
+
 
 
 
@@ -259,6 +265,7 @@ Example syntax:
       #define ID replacement-list EOL
 
 
+
 3.1.1 Static semantics specifications
 -------------------------------------
 
@@ -269,6 +276,7 @@ do04. The identifier ID must be immediately followed by whitespace
 
 do06. Whitespace before or after the replacement-list is not
       considered to be part of the replacement-list.
+
 
 
 3.1.2 Evaluation semantics specifications
@@ -295,7 +303,6 @@ do28. Two replacement lists are identical if and only if the
 
 
 
-
 3.2 The '#define' function-like macro directive
 -----------------------------------------------
 
@@ -307,6 +314,7 @@ Example syntax:
       #define ID(identifier-list) replacement-list EOL
       #define ID(...) replacement-list EOL
       #define ID(identifier-list, ...) replacement-list EOL
+
 
 
 3.2.1 Static semantics specifications
@@ -334,6 +342,7 @@ df16. The '...' between the parentheses specifies that the function-like
       with a variable number of arguments.)
 
 
+
 3.2.2 Evaluation semantics specifications
 -----------------------------------------
 
@@ -351,11 +360,13 @@ df34. An identifier currently defined as a function-like macro shall not
       replacement lists are identical (as in C 2023).
 
 
+
 3.3 The '#undef' directive
 --------------------------
 
 Example syntax:
       #undef ID EOL
+
 
 
 3.3.1 Static semantics specifications
@@ -367,6 +378,7 @@ ud02. ID shall not be one of the macros defined in section 7 "Predefined macros"
 ud04. The specified identifier may or may not have been defined.
 
 
+
 3.3.2 Evaluation semantics specifications
 -----------------------------------------
 
@@ -375,6 +387,8 @@ ud20. If no definition exists for the identifier ID, this directive has
 
 ud22. The definition for the object-like macro or function-like macro
       named by ID is removed.
+
+
 
 3.4 The '#include' directive
 ----------------------------
@@ -418,6 +432,7 @@ in26. A #include directive may appear in an included file, up to a
 in28. Unlike INCLUDE lines (see Fortran 2023 section 6.4, "Including source text"),
       the #include directive is not prohibited from including the
       same source file at a deeper level of nesting.
+
 
 
 3.5 The '#if', '#ifdef', '#ifndef', '#elif', '#elifdef',
@@ -560,6 +575,7 @@ ix65. When all controlling expressions in the <if-head> construct and
       all <group>s in these constructs are skipped.
 
 
+
 3.6 The '#error' and '#warning' directives
 ------------------------------------------
 
@@ -589,6 +605,7 @@ ew06. The processor shall reject a submitted program if the processor
 ew10. Additional behavior is processor-dependent.
 
 
+
 3.7 The '#line' directive
 -------------------------
 
@@ -615,6 +632,8 @@ li20. In both forms, the #line directive causes the processor
 li24. In the second form, the #line directive causes the processor
       to change the presumed file name of the source file to be the
       contents of the CHARACTER_STRING.
+
+
 
 3.8 The '#pragma' directive
 ---------------------------
@@ -646,11 +665,13 @@ pr24. Any #pragma that is not recognized by the processor
       is ignored.
 
 
+
 3.9 The null directive
 ----------------------
 
 Example syntax:
         # EOL
+
 
 3.9.1 Static semantics specifications
 -------------------------------------
@@ -665,11 +686,13 @@ nu02. The only tokens allowed on a null directive are the '#' and
 nu10. The null directive has no effect.
 
 
+
 3.10 The processor-dependent directive
 --------------------------------------
 
 Example syntax:
         # token-list EOL
+
 
 3.10.1 Static semantics specifications
 --------------------------------------
@@ -694,6 +717,7 @@ NOTE: This section is currently incomplete. A self-contained
 specification for macro recognition and expansion will appear in a
 forthcoming paper.
 
+
 4.1 Comparison to Macro recognition and expansion in CPP
 --------------------------------------------------------
 
@@ -711,17 +735,21 @@ me10. When determining argument boundaries in the invocation of a
 Additional details are still under discussion and will be outlined in
 a future paper.
 
+
 4.2 The identifiers __VA_ARGS__ and __VA_OPT__
 ----------------------------------------------
 
 As specified in C 2023 section 6.10.5.1, see also section 4.1
 above.
 
+
 4.9 The '#' and '##' operators
 ------------------------------
 
 As specified in C 2023 section 6.10.5.{2,3}, see also section 4.1
 above.
+
+
 
 
 5 Expressions allowed in #if and #elif directives
@@ -843,6 +871,9 @@ op13. The logical AND operator guarantees left-to-right evaluation; if the first
       resulting value is 0. Otherwise, the second operand is evaluated
       and provides the resulting value.
 
+
+
+
 7 Predefined macros
 ===================
 
@@ -875,6 +906,7 @@ pm15. The presumed source file name and line number can be changed by the #line
 
 The following macro names shall be defined by the processor:
 
+
 7.1 __LINE__
 ------------
 
@@ -882,11 +914,13 @@ pm20. '__LINE__' shall be predefined to a WHOLE_NUMBER representing
       the presumed line number (within the current source file)
       of the current source line.
 
+
 7.2 __FILE__
 ------------
 
 pm30. '__FILE__' shall be predefined to a CHARACTER_STRING representing
       the presumed name of the current source file
+
 
 7.3 __DATE__
 ------------
@@ -902,6 +936,7 @@ pm41. '__DATE__' shall be a character literal constant of the form "Mmm dd yyyy"
 pm42. If the date of translation is not available, a processor-dependent
       valid date shall be supplied.
 
+
 7.4 __TIME__
 ------------
 
@@ -915,8 +950,10 @@ pm51. '__TIME__' shall be a character literal constant of the form "hh:mm:ss",
 pm52. If the time of translation is not available, a processor-dependent
       valid time shall be supplied.
 
+
 7.5 __STDF__
 ------------
+
 __STDF__ is an analog to __STDC__ in C and __cplusplus in C++. Its
 primary role is to provide preprocessor-visible and vendor-independent
 identification of the underlying target language (i.e., "the processor
@@ -924,6 +961,9 @@ is Fortran"), which enables one to write multi-language header files
 with conditional compilation based on language.
 
 pm61. '__STDF__' shall be predefined to the WHOLE_NUMBER 1
+
+
+
 
 Appendix A: Divergences from C
 ==============================

--- a/drafts/25-xxx-specifications.txt
+++ b/drafts/25-xxx-specifications.txt
@@ -20,7 +20,7 @@ a cpp-like preprocessor for Fortran 202Y (paper 25-114r2).
 This is the formal specifications document, revised according to the
 discussion arising from 25-114r2.
 
-Terminology: For the purpose of this specification, the 'preprocessor'
+Terminology: For the purpose of this specification, the "preprocessor"
 encompasses any stages of preprocessing of the input text. For didactic
 purposes, that might include additional phases of "preprocessing" that
 help define the expected priorities of preprocessing behaviors. (In past
@@ -151,7 +151,7 @@ co07. '/*' ... '*/' comments on directive lines are replaced by a
       single space, as specified in C 2023 section 5.1.1.2 bullet 3.
 
 co09. In a directive line, the '!' character is not interpreted as introducing
-      a Fortran-style comment, and neither the `!` character nor any subsequent
+      a Fortran-style comment, and neither the '!' character nor any subsequent
       text are removed by the preprocessor.
 
 co11. Directive lines (by definition) cannot contain Fortran
@@ -328,7 +328,7 @@ df10. The replacement-list may be the empty sequence of tokens.
 df12. Whitespace before or after the replacement-list is not
       considered to be part of the replacement-list.
 
-df16. The "..." between the parentheses specifies that the function-like
+df16. The '...' between the parentheses specifies that the function-like
       macro may be invoked with a variable number of arguments. (See the
       section "Macro recognition and expansion" for the semantics of function-like macros
       with a variable number of arguments.)
@@ -389,7 +389,7 @@ Example syntax:
 --------------------------------------
 
 in06. In the second form, the character-list is any sequence of
-      processor-dependent characters except EOL and `>`.
+      processor-dependent characters except EOL and '>'.
 
 in08. In the third form, the token-list does not match the previous
       two forms.
@@ -478,12 +478,12 @@ if30. The conditional directive chains must properly nest.
 
 
 ix05. The #ifdef and #ifndef directives are evaluated as if they had been
-      written "#if defined(ID)" and "#if !defined(ID)" respectively.
+      written '#if defined(ID)' and '#if !defined(ID)' respectively.
       (For brevity, the descriptions of #ifdef and #ifndef directives
       below are omitted, and assume this transformation.)
 
 ix10. The #elifdef and #elifndef directives are evaluated as if they had
-      been written "#elif defined(ID)" and "#elif !defined(ID)"
+      been written '#elif defined(ID)' and '#elif !defined(ID)'
       respectively. (For brevity, the descriptions below
       assume this transformation has been made).
 
@@ -584,7 +584,7 @@ ew04. The processor produces a diagnostic message that includes
       the token-list.
 
 ew06. The processor shall reject a submitted program if the processor
-      encounters a `#error` directive during preprocessing.
+      encounters a '#error' directive during preprocessing.
 
 ew10. Additional behavior is processor-dependent.
 
@@ -628,7 +628,7 @@ Example syntax:
 
 pr02. The token-list may not be empty.
 
-pr10. The token-list shall not begin with the identifier `STDF`, either
+pr10. The token-list shall not begin with the identifier 'STDF', either
       before or after macro expansion.
 
 
@@ -704,8 +704,8 @@ have consensus amongst the authors:
 
 me10. When determining argument boundaries in the invocation of a
       function-like macro, FPP ignores commas surrounded by matching
-      sets of `[  ]` or `(/  /)` brackets, in addition to matching
-      sets of `(  )` parentheses (as specified in C 2023 section
+      sets of '[  ]' or '(/  /)' brackets, in addition to matching
+      sets of '(  )' parentheses (as specified in C 2023 section
       6.10.5-11).
 
 Additional details are still under discussion and will be outlined in
@@ -729,14 +729,14 @@ above.
 
 
 ex05. When evaluating a #if or #elif directive, first every instance of the
-      `defined ID` or `defined(ID)` operator is evaluated and replaced with
-      the resulting WHOLE_NUMBER. A `defined` expression evaluates to 1 if
+      'defined ID' or 'defined(ID)' operator is evaluated and replaced with
+      the resulting WHOLE_NUMBER. A 'defined' expression evaluates to 1 if
       the identifier is currently defined as a macro name (that is, if it is
-      predefined or if it has been the subject of a `#define` preprocessing
-      directive without an intervening `#undef` directive with the same
+      predefined or if it has been the subject of a '#define' preprocessing
+      directive without an intervening '#undef' directive with the same
       subject identifier), 0 if it is not.
 
-ex10. When evaluating a #if or #elif directive and after `define` processing
+ex10. When evaluating a #if or #elif directive and after 'define' processing
       described in ex05, the token-list is then subjected to macro expansion
       and replacement (see the section "Macro recognition and expansion").
       This results in a token-list of the expression to be
@@ -850,24 +850,24 @@ pm00. Macro names beginning with a leading underscore followed by an uppercase
       letter or a second underscore are reserved to the processor. Reserved
       names shall not be the subject of a #define or #undef preprocessing
       directive within a program unit.
-      [Note: Any macro name matching the regular expression `/^_[A-Z_][A-Za-z0-9_]*$/`
+      [Note: Any macro name matching the regular expression '/^_[A-Z_][A-Za-z0-9_]*$/'
       is considered reserved.]
 
 pm01. Any macro name predefined by the processor shall begin with a
       leading underscore followed by an uppercase letter or a second
       underscore.
 
-pm02. The processor shall not predefine the macro `__cplusplus`,
-      nor any macro whose name starts with `__STDC`.
+pm02. The processor shall not predefine the macro '__cplusplus',
+      nor any macro whose name starts with '__STDC'.
 
 pm03. Unless listed in the following subclauses, the processor shall not
-      predefine any macro whose name starts with `__STDF` or `__stdf`.
+      predefine any macro whose name starts with '__STDF' or '__stdf'.
 
 pm10. The values of the predefined macros listed in the following subclauses
-      (except for `__FILE__` and `__LINE__`) remain constant throughout the
+      (except for '__FILE__' and '__LINE__') remain constant throughout the
       program unit.
 
-pm12. The identifier `defined` shall not be the subject of a #define or a #undef
+pm12. The identifier 'defined' shall not be the subject of a #define or a #undef
       preprocessing directive.
 
 pm15. The presumed source file name and line number can be changed by the #line
@@ -878,23 +878,23 @@ The following macro names shall be defined by the processor:
 7.1 __LINE__
 ------------
 
-pm20. `__LINE__` shall be predefined to a WHOLE_NUMBER representing
+pm20. '__LINE__' shall be predefined to a WHOLE_NUMBER representing
       the presumed line number (within the current source file)
       of the current source line.
 
 7.2 __FILE__
 ------------
 
-pm30. `__FILE__` shall be predefined to a CHARACTER_STRING representing
+pm30. '__FILE__' shall be predefined to a CHARACTER_STRING representing
       the presumed name of the current source file
 
 7.3 __DATE__
 ------------
 
-pm40. `__DATE__` shall be predefined to a CHARACTER_STRING representing
+pm40. '__DATE__' shall be predefined to a CHARACTER_STRING representing
       the date of translation of the preprocessing program unit
 
-pm41. `__DATE__` shall be a character literal constant of the form "Mmm dd yyyy",
+pm41. '__DATE__' shall be a character literal constant of the form "Mmm dd yyyy",
       where the names of the months are the same as those specified in C 2023 for the
       asctime function, and the first character of dd is a space character if the
       value is less than 10.
@@ -905,10 +905,10 @@ pm42. If the date of translation is not available, a processor-dependent
 7.4 __TIME__
 ------------
 
-pm50. `__TIME__` shall be predefined to a CHARACTER_STRING representing
+pm50. '__TIME__' shall be predefined to a CHARACTER_STRING representing
       the time of translation of the preprocessing program unit
 
-pm51. `__TIME__` shall be a character literal constant of the form "hh:mm:ss",
+pm51. '__TIME__' shall be a character literal constant of the form "hh:mm:ss",
       where hh is the hour of the day, mm is the minutes of the hour, and ss is the
       seconds of the minute.
 
@@ -923,7 +923,7 @@ identification of the underlying target language (i.e., "the processor
 is Fortran"), which enables one to write multi-language header files
 with conditional compilation based on language.
 
-pm61. `__STDF__` shall be predefined to the WHOLE_NUMBER 1
+pm61. '__STDF__' shall be predefined to the WHOLE_NUMBER 1
 
 Appendix A: Divergences from C
 ==============================
@@ -937,33 +937,33 @@ as a reference for readers to assist in comparisons.
 
 General differences include:
 
-dfc10. FPP does not recognize `//`-style comments on directive lines.
+dfc10. FPP does not recognize '//'-style comments on directive lines.
 
-dfc20. FPP omits the `#embed` directive added in C 2023.
+dfc20. FPP omits the '#embed' directive added in C 2023.
 
 dfc30. FPP omits (and forbids) many predefined macros whose names begin
-       with `__STDC`.
+       with '__STDC'.
 
 dfc40. FPP expands macro invocations inside Fortran comments on
        source lines and in Fortran comment lines.
 
-dfc60. The token-list in the FPP `#pragma` directive may not be empty.
+dfc60. The token-list in the FPP '#pragma' directive may not be empty.
 
-Differences in the conditional expression grammar for `#if` and
-`#elif` directives include:
+Differences in the conditional expression grammar for '#if' and
+'#elif' directives include:
 
 dfc80. FPP omits the comma operator.
 
 dfc82. FPP omits character literal constants.
 
-dfc84. FPP omits the `true` and `false` boolean literals added in
+dfc84. FPP omits the 'true' and 'false' boolean literals added in
        C 2023.
 
-dfc86. FPP omits the `__has_include` expression added in C 2023.
+dfc86. FPP omits the '__has_include' expression added in C 2023.
 
-dfc88. FPP omits the `__has_c_attribute` expression added in C 2023.
+dfc88. FPP omits the '__has_c_attribute' expression added in C 2023.
 
-dfc90. FPP omits the `__has_embed` expression added in C 2023.
+dfc90. FPP omits the '__has_embed' expression added in C 2023.
 
 Differences in macro recognition and expansion are currently
 documented explicitly in section 4.1.

--- a/drafts/25-xxx-specifications.txt
+++ b/drafts/25-xxx-specifications.txt
@@ -166,7 +166,7 @@ Translation phases).
 As such, there is a specific lexicon of tokens recognized by
 the preprocessor (including unrecognizable tokens).
 As in C 2023, these tokens are recognized after any line and
-comment handling specified in the "Line" and "Comments" sections above.
+comment handling specified in section 2.1 "Lines" and section 2.4 "Comments" above.
 
 We use illustrative syntax to describe the directive specifications,
 and the translation behavior of the preprocess on Fortran comment lines
@@ -215,8 +215,8 @@ below.
 We use illustrative syntax in the detailed descriptions. Detailed
 syntax will appear in a paper to be named later.
 
-Most directives take a sequence of tokens (as defined in the section
-"Token lexicon" above). In the detailed descriptions and illustrative
+Most directives take a sequence of tokens (as defined in
+section 2.5 "Token lexicon" above). In the detailed descriptions and illustrative
 syntax below, we denote these as just "token-list" or
 "replacement-list".
 
@@ -252,8 +252,8 @@ di10. The processor-dependent directive
 3.1 The '#define' object-like macro directive
 ---------------------------------------------
 
-See also the rules for expanding object-like macros in the
-section "Macro recognition and expansion" below.
+See also the rules for expanding object-like macros in
+section 4 "Macro recognition and expansion" below.
 
 Example syntax:
       #define ID replacement-list EOL
@@ -300,7 +300,7 @@ do28. Two replacement lists are identical if and only if the
 -----------------------------------------------
 
 See also the rules for expanding function-like macros in the
-section "Macro recognition and expansion" below.
+section 4 "Macro recognition and expansion" below.
 
 Example syntax:
       #define ID() replacement-list EOL
@@ -320,7 +320,7 @@ df04. The identifier-list is a comma-separated list of ID tokens.
 df06. No identifier may appear more than once in the identifier-list.
 
 df08. The identifier names in the identifier-list define macro "parameters" that affect
-      macro expansion of the replacement list. (See the section "Macro recognition and
+      macro expansion of the replacement list. (See section 4 "Macro recognition and
       expansion" for the semantics of function-like macro expansion.)
 
 df10. The replacement-list may be the empty sequence of tokens.
@@ -329,8 +329,8 @@ df12. Whitespace before or after the replacement-list is not
       considered to be part of the replacement-list.
 
 df16. The '...' between the parentheses specifies that the function-like
-      macro may be invoked with a variable number of arguments. (See the
-      section "Macro recognition and expansion" for the semantics of function-like macros
+      macro may be invoked with a variable number of arguments. (See
+      section 4 "Macro recognition and expansion" for the semantics of function-like macros
       with a variable number of arguments.)
 
 
@@ -361,8 +361,8 @@ Example syntax:
 3.3.1 Static semantics specifications
 -------------------------------------
 
-ud02. ID shall not be one of the macros defined in the "Predefined macros"
-      section below.
+ud02. ID shall not be one of the macros defined in section 7 "Predefined macros"
+       below.
 
 ud04. The specified identifier may or may not have been defined.
 
@@ -399,7 +399,7 @@ in08. In the third form, the token-list does not match the previous
 -----------------------------------------
 
 in18. In the third form, the token-list is processed as in Fortran
-      source fragments (see the section on "Macro recognition and
+      source fragments (see section 4 "Macro recognition and
       expansion" below). The directive resulting after all replacements
       shall match one of the previous two forms, and evaluation proceeds
       as such.
@@ -415,7 +415,7 @@ in24. If the file is located, the processor replaces the #include
 in26. A #include directive may appear in an included file, up to a
       processor-defined nesting limit.
 
-in28. Unlike INCLUDE lines (see the section on "INCLUDE lines"),
+in28. Unlike INCLUDE lines (see Fortran 2023 section 6.4, "Including source text"),
       the #include directive is not prohibited from including the
       same source file at a deeper level of nesting.
 
@@ -510,17 +510,17 @@ ix14. In the descriptions below, <group> constructs that are not
 
 ix15. Before evaluating the token-lists in any <if-head> and <if-elif>
       constructs that are not skipped, macros in the token-lists are
-      processed as described in the section "Macro recognition and expansion".
+      processed as described in section 4 "Macro recognition and expansion".
 
 ix20. After expansion, the resulting token list in <if-head> and <if-elif>
       constructs that are not skipped must be able to be parsed as a valid integer expression as
-      described in the section "Expressions allowed in #if and #elif
+      described in section 5 "Expressions allowed in #if and #elif
       directives" static semantics. This expression is called the "controlling
       expression" for the directive.
 
 ix25. The values of controlling expressions in <if-head> and <if-elif>
       constructs are evaluated according to the evaluation semantics
-      described in the section "Expressions allowed in #if and #elif
+      described in section 5 "Expressions allowed in #if and #elif
       directives".
 
 ix30. If the controlling expression in an <if-head> evaluates to a
@@ -738,7 +738,7 @@ ex05. When evaluating a #if or #elif directive, first every instance of the
 
 ex10. When evaluating a #if or #elif directive and after 'define' processing
       described in ex05, the token-list is then subjected to macro expansion
-      and replacement (see the section "Macro recognition and expansion").
+      and replacement (see section 4 "Macro recognition and expansion").
       This results in a token-list of the expression to be
       evaluated.
 

--- a/drafts/25-xxx-specifications.txt
+++ b/drafts/25-xxx-specifications.txt
@@ -635,9 +635,9 @@ pr10. The token-list shall not begin with the identifier `STDF`, either
 3.8.2 Evaluation semantics specifications
 -----------------------------------------
 
-pr20. The semantics of the token-list are processor-dependent. 
-      In particular, it is processor-dependent whether macro 
-      expansion is performed on the token-list. 
+pr20. The semantics of the token-list are processor-dependent.
+      In particular, it is processor-dependent whether macro
+      expansion is performed on the token-list.
 
 pr22. The #pragma directive causes the processor to behave
       in a processor-defined manner.
@@ -729,18 +729,18 @@ above.
 
 
 ex05. When evaluating a #if or #elif directive, first every instance of the
-      `defined ID` or `defined(ID)` operator is evaluated and replaced with 
-      the resulting WHOLE_NUMBER. A `defined` expression evaluates to 1 if 
-      the identifier is currently defined as a macro name (that is, if it is 
-      predefined or if it has been the subject of a `#define` preprocessing 
-      directive without an intervening `#undef` directive with the same 
+      `defined ID` or `defined(ID)` operator is evaluated and replaced with
+      the resulting WHOLE_NUMBER. A `defined` expression evaluates to 1 if
+      the identifier is currently defined as a macro name (that is, if it is
+      predefined or if it has been the subject of a `#define` preprocessing
+      directive without an intervening `#undef` directive with the same
       subject identifier), 0 if it is not.
-      
-ex10. When evaluating a #if or #elif directive and after `define` processing 
+
+ex10. When evaluating a #if or #elif directive and after `define` processing
       described in ex05, the token-list is then subjected to macro expansion
       and replacement (see the section "Macro recognition and expansion").
       This results in a token-list of the expression to be
-      evaluated. 
+      evaluated.
 
 ex12. Since expression evaluation occurs *after* macro expansion, there will
       be no object-like macro or function-like macro invocations left to expand.
@@ -755,7 +755,7 @@ ex17. Preprocessing computes the integer value of conditional expressions
       determine the truth or falsity of the controlling expression.
 
 ex20. The processor shall reject a program if evaluation of
-      the expression generates a computational error (such 
+      the expression generates a computational error (such
       as divide by zero).
 
 ex25. When the expression evaluates to zero, the controlling expression
@@ -839,9 +839,9 @@ op12. The logical OR operator guarantees left-to-right evaluation; if the first
       and provides the resulting value.
 
 op13. The logical AND operator guarantees left-to-right evaluation; if the first
-      operand evaluates to 0, the second operand is not evaluated and the 
+      operand evaluates to 0, the second operand is not evaluated and the
       resulting value is 0. Otherwise, the second operand is evaluated
-      and provides the resulting value.      
+      and provides the resulting value.
 
 7 Predefined macros
 ===================
@@ -967,4 +967,3 @@ dfc90. FPP omits the `__has_embed` expression added in C 2023.
 
 Differences in macro recognition and expansion are currently
 documented explicitly in section 4.1.
-

--- a/drafts/25-xxx-specifications.txt
+++ b/drafts/25-xxx-specifications.txt
@@ -11,8 +11,8 @@ References: 25-114r2 Fortran preprocessor requirements
                    (working draft N3096)
 
 
-1. Introduction
-===============
+1 Introduction
+==============
 
 At its meeting Feb 19, 2025, J3 decided to approve requirements for
 a cpp-like preprocessor for Fortran 202Y (paper 25-114r2).
@@ -29,7 +29,7 @@ handling, and tokenization for the preprocessor.)
 
 
 2 Lexical specifications
-------------------------
+========================
 
 2.1 Lines
 ---------
@@ -260,7 +260,7 @@ Example syntax:
 
 
 3.1.1 Static semantics specifications
---------------------------------------
+-------------------------------------
 
 do02. The replacement-list is a (possibly empty) sequence of tokens.
 
@@ -310,7 +310,7 @@ Example syntax:
 
 
 3.2.1 Static semantics specifications
---------------------------------------
+-------------------------------------
 
 df02. The identifier ID must be immediately followed by the
       left parenthesis '(' with no intervening whitespace.
@@ -386,7 +386,7 @@ Example syntax:
 
 
 3.4.1 Static semantics specifications
---------------------------------------
+-------------------------------------
 
 in06. In the second form, the character-list is any sequence of
       processor-dependent characters except EOL and '>'.
@@ -422,7 +422,7 @@ in28. Unlike INCLUDE lines (see the section on "INCLUDE lines"),
 
 3.5 The '#if', '#ifdef', '#ifndef', '#elif', '#elifdef',
       '#elifndef', '#else', '#endif' conditional directives
----------------------------------------------------------
+-----------------------------------------------------------
 
 Example syntax (extra spacing for illustration purposes only):
     General form:
@@ -572,7 +572,7 @@ error conditions in the input.
 
 
 3.6.1 Static semantics specifications
---------------------------------------
+-------------------------------------
 
 
 3.6.2 Evaluation semantics specifications
@@ -598,7 +598,7 @@ Example syntax:
 
 
 3.7.1 Static semantics specifications
---------------------------------------
+-------------------------------------
 
 li02. The WHOLE_NUMBER shall not be zero.
 
@@ -653,7 +653,7 @@ Example syntax:
         # EOL
 
 3.9.1 Static semantics specifications
---------------------------------------
+-------------------------------------
 
 nu02. The only tokens allowed on a null directive are the '#' and
       the end-of-line indicator EOL.
@@ -666,7 +666,7 @@ nu10. The null directive has no effect.
 
 
 3.10 The processor-dependent directive
---------------------------------
+--------------------------------------
 
 Example syntax:
         # token-list EOL
@@ -688,7 +688,7 @@ nd20. The result of evaluating a processor-dependent directive is processor-depe
 
 
 4 Macro recognition and expansion
----------------------------------
+=================================
 
 NOTE: This section is currently incomplete. A self-contained
 specification for macro recognition and expansion will appear in a

--- a/drafts/25-xxx-specifications.txt
+++ b/drafts/25-xxx-specifications.txt
@@ -40,7 +40,7 @@ li00. The Fortran preprocessor recognizes three distinct types of lines:
 
 li11. A line that has a '#'
       character as the first non-blank character of the line is a
-      directive line (as required by C 2023 6.10.1 paragraph 2),
+      directive line (as required by C 2023 section 6.10.1 paragraph 2),
       except when otherwise specified by the next two rules.
 
 li13. In fixed-form input files, a '#' in column 6 of a non-comment
@@ -60,7 +60,7 @@ li19. The maximum length of a preprocessor directive (including
       continuation text) is one million characters.
 
 li21. A source file that ends with a directive line shall neither end with a '\',
-      nor a '\' followed immediately by a new-line (analogously to C 2023 5.1.1.2 bullet 2).
+      nor a '\' followed immediately by a new-line (analogously to C 2023 section 5.1.1.2 bullet 2).
 
 li31. Fortran comment lines are defined as in 25-007 6.3.2.3 and
       6.3.3.2.
@@ -148,7 +148,7 @@ co05. '/*' ... '*/' comments on directive lines shall extend past a
       continuation line.
 
 co07. '/*' ... '*/' comments on directive lines are replaced by a
-      single space, as specified in C 2023 5.1.1.2 bullet 3.
+      single space, as specified in C 2023 section 5.1.1.2 bullet 3.
 
 co09. In a directive line, the '!' character is not interpreted as introducing
       a Fortran-style comment, and neither the `!` character nor any subsequent
@@ -161,7 +161,7 @@ co11. Directive lines (by definition) cannot contain Fortran
 2.5 Token lexicon
 -----------------
 
-The preprocessor decomposes the source file into preprocessing tokens (see C 2023 5.1.1.2
+The preprocessor decomposes the source file into preprocessing tokens (see C 2023 section 5.1.1.2
 Translation phases).
 As such, there is a specific lexicon of tokens recognized by
 the preprocessor (including unrecognizable tokens).
@@ -770,7 +770,7 @@ ex25. When the expression evaluates to zero, the controlling expression
 op01. To maintain compatibility with the use of C preprocessing directives
       in many existing Fortran programs, the operators allowed in
       controlling expressions in #if and #elif expressions are a subset of
-      those defined in the C 2023 standard §6.5 "Expressions" and §6.6
+      those defined in C 2023 section 6.5 "Expressions" and section 6.6
       "Constant expressions".
 
 op03. A "precedence level" is assigned to each operator that determines


### PR DESCRIPTION
- Remove extraneous white space at the end of lines
- Use only one space after period (full stop)
- Consistently use "section" when referring to the C 2023 standard
- Consistently use '...' for literal, "..." for figurative terms
- Correct underlining of headings
- Add section numbers as well as titles to cross-references
- Improve inter-heading spacing; add more blank lines, generally
- Fix line lengths and some row lengths

